### PR TITLE
Add error messages of token expired 1010.

### DIFF
--- a/src/core/TuyaOpenAPI.ts
+++ b/src/core/TuyaOpenAPI.ts
@@ -29,6 +29,7 @@ const DEFAULT_ENDPOINTS = {
 
 export const LOGIN_ERROR_MESSAGES = {
   1004: 'Please make sure your endpoint, accessId, accessKey is right.',
+  1010: 'Please make sure you are not running multiple HomeBridge or HomeAssistant instance with same tuya account.',
   1104: 'Please make sure your endpoint, accessId, accessKey is right.',
   1106: 'Please make sure your countryCode, username, password, appSchema is correct, and app account is linked with cloud project.',
   2401: 'Username or password is wrong.',


### PR DESCRIPTION
Most time, 1010 means you are login the same account at another place.