### PR TITLE
Changes to device functions.

### DIFF
--- a/src/accessory/AirQualitySensorAccessory.ts
+++ b/src/accessory/AirQualitySensorAccessory.ts
@@ -12,7 +12,7 @@ export default class AirQualitySensorAccessory extends BaseAccessory {
 
     service.getCharacteristic(this.Characteristic.AirQuality)
       .onGet(() => {
-        const status = this.device.getDeviceStatus('pm25_value');
+        const status = this.device.getStatus('pm25_value');
         if (status) {
           let pm25 = Math.max(0, status?.value as number);
           pm25 = Math.min(1000, pm25);
@@ -30,30 +30,30 @@ export default class AirQualitySensorAccessory extends BaseAccessory {
         return this.Characteristic.AirQuality.UNKNOWN;
       });
 
-    if (this.device.getDeviceStatus('pm25_value')) {
+    if (this.device.getStatus('pm25_value')) {
       service.getCharacteristic(this.Characteristic.PM2_5Density)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('pm25_value');
+          const status = this.device.getStatus('pm25_value');
           let pm25 = Math.max(0, status?.value as number);
           pm25 = Math.min(1000, pm25);
           return pm25;
         });
     }
 
-    if (this.device.getDeviceStatus('pm10')) {
+    if (this.device.getStatus('pm10')) {
       service.getCharacteristic(this.Characteristic.PM10Density)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('pm10');
+          const status = this.device.getStatus('pm10');
           let pm25 = Math.max(0, status?.value as number);
           pm25 = Math.min(1000, pm25);
           return pm25;
         });
     }
 
-    if (this.device.getDeviceStatus('voc_value')) {
+    if (this.device.getStatus('voc_value')) {
       service.getCharacteristic(this.Characteristic.VOCDensity)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('voc_value');
+          const status = this.device.getStatus('voc_value');
           let voc = Math.max(0, status?.value as number);
           voc = Math.min(1000, voc);
           return voc;

--- a/src/accessory/BaseAccessory.ts
+++ b/src/accessory/BaseAccessory.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { PlatformAccessory, Service, Characteristic } from 'homebridge';
 
-import { TuyaDeviceFunction, TuyaDeviceStatus } from '../device/TuyaDevice';
+import { TuyaDeviceSchema, TuyaDeviceStatus } from '../device/TuyaDevice';
 import { TuyaPlatform } from '../platform';
 
 const MANUFACTURER = 'Tuya Inc.';
@@ -29,11 +29,8 @@ export default class BaseAccessory {
     this.addAccessoryInfoService();
     this.addBatteryService();
 
-    for (const deviceFunction of this.device.functions) {
-      const status = this.device.getDeviceStatus(deviceFunction.code);
-      if (status) {
-        this.configureService(deviceFunction);
-      }
+    for (const schema of this.device.schema) {
+      this.configureService(schema);
     }
 
     this.onDeviceStatusUpdate(this.device.status);
@@ -101,20 +98,20 @@ export default class BaseAccessory {
   }
 
   getBatteryState() {
-    return this.device.getDeviceStatus('battery_state');
+    return this.device.getStatus('battery_state');
   }
 
   getBatteryPercentage() {
-    return this.device.getDeviceStatus('battery_percentage')
-      || this.device.getDeviceStatus('residual_electricity');
+    return this.device.getStatus('battery_percentage')
+      || this.device.getStatus('residual_electricity');
   }
 
   getChargeState() {
-    return this.device.getDeviceStatus('charge_state');
+    return this.device.getStatus('charge_state');
   }
 
 
-  configureService(deviceFunction: TuyaDeviceFunction) {
+  configureService(schema: TuyaDeviceSchema) {
 
   }
 

--- a/src/accessory/CarbonDioxideSensorAccessory.ts
+++ b/src/accessory/CarbonDioxideSensorAccessory.ts
@@ -10,20 +10,20 @@ export default class CarbonDioxideSensorAccessory extends BaseAccessory {
     const service = this.accessory.getService(this.Service.CarbonDioxideSensor)
       || this.accessory.addService(this.Service.CarbonDioxideSensor);
 
-    if (this.device.getDeviceStatus('co2_state')) {
+    if (this.device.getStatus('co2_state')) {
       service.getCharacteristic(this.Characteristic.CarbonDioxideDetected)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('co2_state');
+          const status = this.device.getStatus('co2_state');
           return (status!.value === 'alarm') ?
             this.Characteristic.CarbonDioxideDetected.CO2_LEVELS_ABNORMAL :
             this.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL;
         });
     }
 
-    if (this.device.getDeviceStatus('co2_value')) {
+    if (this.device.getStatus('co2_value')) {
       service.getCharacteristic(this.Characteristic.CarbonDioxideLevel)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('co2_value');
+          const status = this.device.getStatus('co2_value');
           let value = Math.max(0, status!.value as number);
           value = Math.min(100000, value);
           return value;

--- a/src/accessory/CarbonMonoxideSensorAccessory.ts
+++ b/src/accessory/CarbonMonoxideSensorAccessory.ts
@@ -10,22 +10,22 @@ export default class CarbonMonoxideSensorAccessory extends BaseAccessory {
     const service = this.accessory.getService(this.Service.CarbonMonoxideSensor)
       || this.accessory.addService(this.Service.CarbonMonoxideSensor);
 
-    if (this.device.getDeviceStatus('co_status')
-      || this.device.getDeviceStatus('co_state')) {
+    if (this.device.getStatus('co_status')
+      || this.device.getStatus('co_state')) {
       service.getCharacteristic(this.Characteristic.CarbonMonoxideDetected)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('co_status')
-            || this.device.getDeviceStatus('co_state');
+          const status = this.device.getStatus('co_status')
+            || this.device.getStatus('co_state');
           return (status!.value === 'alarm' || status!.value === '1') ?
             this.Characteristic.CarbonMonoxideDetected.CO_LEVELS_ABNORMAL :
             this.Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL;
         });
     }
 
-    if (this.device.getDeviceStatus('co_value')) {
+    if (this.device.getStatus('co_value')) {
       service.getCharacteristic(this.Characteristic.CarbonMonoxideLevel)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('co_value');
+          const status = this.device.getStatus('co_value');
           let value = Math.max(0, status!.value as number);
           value = Math.min(100, value);
           return value;

--- a/src/accessory/ContactSensorAccessory.ts
+++ b/src/accessory/ContactSensorAccessory.ts
@@ -12,7 +12,7 @@ export default class ContaceSensor extends BaseAccessory {
 
     service.getCharacteristic(this.Characteristic.ContactSensorState)
       .onGet(() => {
-        const status = this.device.getDeviceStatus('doorcontact_state');
+        const status = this.device.getStatus('doorcontact_state');
         return status!.value ?
           this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED:
           this.Characteristic.ContactSensorState.CONTACT_DETECTED;

--- a/src/accessory/GarageDoorAccessory.ts
+++ b/src/accessory/GarageDoorAccessory.ts
@@ -12,8 +12,8 @@ export default class GarageDoorAccessory extends BaseAccessory {
 
     service.getCharacteristic(this.Characteristic.CurrentDoorState)
       .onGet(() => {
-        const currentStatus = this.device.getDeviceStatus('doorcontact_state')!;
-        const targetStatus = this.device.getDeviceStatus('switch_1')!;
+        const currentStatus = this.device.getStatus('doorcontact_state')!;
+        const targetStatus = this.device.getStatus('switch_1')!;
 
         if (currentStatus.value === true && targetStatus.value === true) {
           return this.Characteristic.CurrentDoorState.OPEN;
@@ -31,7 +31,7 @@ export default class GarageDoorAccessory extends BaseAccessory {
 
     service.getCharacteristic(this.Characteristic.TargetDoorState)
       .onGet(() => {
-        const status = this.device.getDeviceStatus('switch_1')!;
+        const status = this.device.getStatus('switch_1')!;
         return status.value ?
           this.Characteristic.TargetDoorState.OPEN :
           this.Characteristic.TargetDoorState.CLOSED;

--- a/src/accessory/HumanPresenceSensorAccessory.ts
+++ b/src/accessory/HumanPresenceSensorAccessory.ts
@@ -7,13 +7,13 @@ export default class HumanPresenceSensorAccessory extends BaseAccessory {
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
-    if (this.device.getDeviceStatus('presence_state')) {
+    if (this.device.getStatus('presence_state')) {
       const service = this.accessory.getService(this.Service.OccupancySensor)
       || this.accessory.addService(this.Service.OccupancySensor);
 
       service.getCharacteristic(this.Characteristic.OccupancyDetected)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('presence_state');
+          const status = this.device.getStatus('presence_state');
           return (status?.value === 'presence') ?
             this.Characteristic.OccupancyDetected.OCCUPANCY_DETECTED :
             this.Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED;

--- a/src/accessory/LeakSensorAccessory.ts
+++ b/src/accessory/LeakSensorAccessory.ts
@@ -12,10 +12,10 @@ export default class LeakSensor extends BaseAccessory {
 
     service.getCharacteristic(this.Characteristic.LeakDetected)
       .onGet(() => {
-        const gas = this.device.getDeviceStatus('gas_sensor_status')
-          || this.device.getDeviceStatus('gas_sensor_state');
-        const ch4 = this.device.getDeviceStatus('ch4_sensor_state');
-        const water = this.device.getDeviceStatus('watersensor_state');
+        const gas = this.device.getStatus('gas_sensor_status')
+          || this.device.getStatus('gas_sensor_state');
+        const ch4 = this.device.getStatus('ch4_sensor_state');
+        const water = this.device.getStatus('watersensor_state');
 
         if ((gas && (gas.value === 'alarm' || gas.value === '1'))
           || (ch4 && ch4.value === 'alarm')

--- a/src/accessory/LegacyAccessoryFactory.ts
+++ b/src/accessory/LegacyAccessoryFactory.ts
@@ -34,6 +34,8 @@ export default class LegacyAccessoryFactory {
       };
     }
 
+    device['functions'] = device.schema;
+
     let handler;
     switch (device.category) {
       case 'kj':

--- a/src/accessory/LightSensorAccessory.ts
+++ b/src/accessory/LightSensorAccessory.ts
@@ -7,13 +7,13 @@ export default class LightSensorAccessory extends BaseAccessory {
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
-    if (this.device.getDeviceStatus('bright_value')) {
+    if (this.device.getStatus('bright_value')) {
       const service = this.accessory.getService(this.Service.LightSensor)
         || this.accessory.addService(this.Service.LightSensor);
 
       service.getCharacteristic(this.Characteristic.CurrentAmbientLightLevel)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('bright_value');
+          const status = this.device.getStatus('bright_value');
           let lightLevel = Math.max(0.0001, status!.value as number);
           lightLevel = Math.min(100000, lightLevel);
           return lightLevel;

--- a/src/accessory/MotionSensorAccessory.ts
+++ b/src/accessory/MotionSensorAccessory.ts
@@ -7,13 +7,13 @@ export default class MotionSensorAccessory extends BaseAccessory {
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
-    if (this.device.getDeviceStatus('pir')) {
+    if (this.device.getStatus('pir')) {
       const service = this.accessory.getService(this.Service.MotionSensor)
         || this.accessory.addService(this.Service.MotionSensor);
 
       service.getCharacteristic(this.Characteristic.MotionDetected)
         .onGet(() => {
-          const status = this.device.getDeviceStatus('pir');
+          const status = this.device.getStatus('pir');
           return (status!.value === 'pir');
         });
     }

--- a/src/accessory/SmokeSensorAccessory.ts
+++ b/src/accessory/SmokeSensorAccessory.ts
@@ -12,8 +12,8 @@ export default class SmokeSensor extends BaseAccessory {
 
     service.getCharacteristic(this.Characteristic.SmokeDetected)
       .onGet(() => {
-        const status = this.device.getDeviceStatus('smoke_sensor_status')
-          || this.device.getDeviceStatus('smoke_sensor_state');
+        const status = this.device.getStatus('smoke_sensor_status')
+          || this.device.getStatus('smoke_sensor_state');
 
         if ((status && (status.value === 'alarm' || status.value === '1'))) {
           return this.Characteristic.LeakDetected.LEAK_DETECTED;

--- a/src/accessory/SwitchAccessory.ts
+++ b/src/accessory/SwitchAccessory.ts
@@ -1,4 +1,4 @@
-import { TuyaDeviceFunction, TuyaDeviceFunctionType } from '../device/TuyaDevice';
+import { TuyaDeviceSchema, TuyaDeviceSchemaType } from '../device/TuyaDevice';
 import BaseAccessory from './BaseAccessory';
 
 export default class SwitchAccessory extends BaseAccessory {
@@ -7,24 +7,24 @@ export default class SwitchAccessory extends BaseAccessory {
     return this.Service.Switch;
   }
 
-  configureService(deviceFunction: TuyaDeviceFunction) {
-    if (deviceFunction.type !== TuyaDeviceFunctionType.Boolean) {
+  configureService(schema: TuyaDeviceSchema) {
+    if (schema.type !== TuyaDeviceSchemaType.Boolean) {
       return;
     }
 
-    const service = this.accessory.getService(deviceFunction.code)
-      || this.accessory.addService(this.mainService(), deviceFunction.name, deviceFunction.code);
+    const service = this.accessory.getService(schema.code)
+      || this.accessory.addService(this.mainService(), schema.code, schema.code);
 
-    service.setCharacteristic(this.Characteristic.Name, deviceFunction.name);
+    service.setCharacteristic(this.Characteristic.Name, schema.code);
 
     service.getCharacteristic(this.Characteristic.On)
       .onGet(async () => {
-        const status = this.device.getDeviceStatus(deviceFunction.code);
+        const status = this.device.getStatus(schema.code);
         return status!.value as boolean;
       })
       .onSet(async (value) => {
         await this.deviceManager.sendCommands(this.device.id, [{
-          code: deviceFunction.code,
+          code: schema.code,
           value: value as boolean,
         }]);
       });

--- a/src/accessory/ValveAccessory.ts
+++ b/src/accessory/ValveAccessory.ts
@@ -1,34 +1,34 @@
-import { TuyaDeviceFunction, TuyaDeviceFunctionType } from '../device/TuyaDevice';
+import { TuyaDeviceSchema, TuyaDeviceSchemaType } from '../device/TuyaDevice';
 import BaseAccessory from './BaseAccessory';
 
 export default class ValueAccessory extends BaseAccessory {
 
-  configureService(deviceFunction: TuyaDeviceFunction) {
-    if (!deviceFunction.code.startsWith('switch')
-      || deviceFunction.type !== TuyaDeviceFunctionType.Boolean) {
+  configureService(schema: TuyaDeviceSchema) {
+    if (!schema.code.startsWith('switch')
+      || schema.type !== TuyaDeviceSchemaType.Boolean) {
       return;
     }
 
-    const service = this.accessory.getService(deviceFunction.code)
-      || this.accessory.addService(this.Service.Valve, deviceFunction.name, deviceFunction.code);
+    const service = this.accessory.getService(schema.code)
+      || this.accessory.addService(this.Service.Valve, schema.code, schema.code);
 
-    service.setCharacteristic(this.Characteristic.Name, deviceFunction.name);
+    service.setCharacteristic(this.Characteristic.Name, schema.code);
     service.setCharacteristic(this.Characteristic.ValveType, this.Characteristic.ValveType.IRRIGATION);
 
     service.getCharacteristic(this.Characteristic.InUse)
       .onGet(() => {
-        const status = this.device.getDeviceStatus(deviceFunction.code);
+        const status = this.device.getStatus(schema.code);
         return status?.value as boolean;
       });
 
     service.getCharacteristic(this.Characteristic.Active)
       .onGet(() => {
-        const status = this.device.getDeviceStatus(deviceFunction.code);
+        const status = this.device.getStatus(schema.code);
         return status?.value as boolean;
       })
       .onSet(value => {
         this.deviceManager.sendCommands(this.device.id, [{
-          code: deviceFunction.code,
+          code: schema.code,
           value: (value as number === 1) ? true : false,
         }]);
       });

--- a/src/accessory/WindowCoveringAccessory.ts
+++ b/src/accessory/WindowCoveringAccessory.ts
@@ -22,7 +22,7 @@ export default class WindowCoveringAccessory extends BaseAccessory {
     this.mainService().getCharacteristic(this.Characteristic.CurrentPosition)
       .onGet(() => {
         if (!this.positionSupported()) {
-          const control = this.device.getDeviceStatus('control');
+          const control = this.device.getStatus('control');
           if (control?.value === 'close') {
             return 0;
           } else if (control?.value === 'stop') {
@@ -64,7 +64,7 @@ export default class WindowCoveringAccessory extends BaseAccessory {
     this.mainService().getCharacteristic(this.Characteristic.TargetPosition)
       .onGet(() => {
         if (!this.positionSupported()) {
-          const control = this.device.getDeviceStatus('control');
+          const control = this.device.getStatus('control');
           if (control?.value === 'close') {
             return 0;
           } else if (control?.value === 'stop') {
@@ -82,17 +82,16 @@ export default class WindowCoveringAccessory extends BaseAccessory {
       .onSet(value => {
         const commands: TuyaDeviceStatus[] = [];
         if (!this.positionSupported()) {
-          const control = this.device.getDeviceStatus('control');
           if (value === 0) {
-            commands.push({ code: control!.code, value: 'close' });
+            commands.push({ code: 'control', value: 'close' });
           } else if (value === 100) {
-            commands.push({ code: control!.code, value: 'open' });
+            commands.push({ code: 'control', value: 'open' });
           } else {
-            commands.push({ code: control!.code, value: 'stop' });
+            commands.push({ code: 'control', value: 'stop' });
           }
         } else {
-          const state = this.getTargetPosition();
-          commands.push({ code: state!.code, value: value as number });
+          const state = this.getTargetPosition()!;
+          commands.push({ code: state.code, value: value as number });
         }
         this.deviceManager.sendCommands(this.device.id, commands);
       })
@@ -102,16 +101,16 @@ export default class WindowCoveringAccessory extends BaseAccessory {
   }
 
   getCurrentPosition() {
-    return this.device.getDeviceStatus('percent_state'); // 0~100
+    return this.device.getStatus('percent_state'); // 0~100
   }
 
   getTargetPosition() {
-    return this.device.getDeviceStatus('percent_control')
-    || this.device.getDeviceStatus('position');  // 0~100
+    return this.device.getStatus('percent_control')
+    || this.device.getStatus('position');  // 0~100
   }
 
   getWorkState() {
-    return this.device.getDeviceStatus('work_state'); // opening, closing
+    return this.device.getStatus('work_state'); // opening, closing
   }
 
   positionSupported() {
@@ -121,9 +120,9 @@ export default class WindowCoveringAccessory extends BaseAccessory {
 
   /*
   isMotorReversed() {
-    const state = this.device.getDeviceStatus('control_back_mode')
-      || this.device.getDeviceStatus('control_back')
-      || this.device.getDeviceStatus('opposite');
+    const state = this.device.getStatus('control_back_mode')
+      || this.device.getStatus('control_back')
+      || this.device.getStatus('opposite');
     if (!state) {
       return false;
     }

--- a/src/device/TuyaCustomDeviceManager.ts
+++ b/src/device/TuyaCustomDeviceManager.ts
@@ -1,4 +1,4 @@
-import TuyaDevice, { TuyaDeviceFunction } from './TuyaDevice';
+import TuyaDevice from './TuyaDevice';
 import TuyaDeviceManager from './TuyaDeviceManager';
 
 export default class TuyaCustomDeviceManager extends TuyaDeviceManager {
@@ -50,16 +50,9 @@ export default class TuyaCustomDeviceManager extends TuyaDeviceManager {
 
     const res = await this.getDeviceListInfo(deviceIDs);
     const devices = (res.result.devices as []).map(obj => new TuyaDevice(obj));
-    const functions = await this.getDeviceListFunctions(deviceIDs);
 
     for (const device of devices) {
-      for (const item of functions) {
-        if (device.product_id === item['product_id']) {
-          device.functions = item['functions'] as TuyaDeviceFunction[];
-          break;
-        }
-      }
-      device.functions = device.functions || [];
+      device.schema = await this.getDeviceSchema(device.id);
     }
 
     this.devices = devices;

--- a/src/device/TuyaDevice.ts
+++ b/src/device/TuyaDevice.ts
@@ -1,5 +1,12 @@
 
-export enum TuyaDeviceFunctionType {
+export enum TuyaDeviceSchemaMode {
+  UNKNOWN = '',
+  READ_WRITE = 'rw',
+  READ_ONLY = 'ro',
+  WRITE_ONLY = 'wo',
+}
+
+export enum TuyaDeviceSchemaType {
   Boolean = 'Boolean',
   Integer = 'Integer',
   Enum = 'Enum',
@@ -8,7 +15,7 @@ export enum TuyaDeviceFunctionType {
   Raw = 'Raw',
 }
 
-export type TuyaDeviceFunctionIntegerProperty = {
+export type TuyaDeviceSchemaIntegerProperty = {
   min: number;
   max: number;
   scale: number;
@@ -16,27 +23,28 @@ export type TuyaDeviceFunctionIntegerProperty = {
   unit: string;
 };
 
-export type TuyaDeviceFunctionEnumProperty = {
+export type TuyaDeviceSchemaEnumProperty = {
   range: string[];
 };
 
-export type TuyaDeviceFunctionJSONProperty = object;
+export type TuyaDeviceSchemaObjectProperty = object;
 
-export type TuyaDeviceFunctionProperty = TuyaDeviceFunctionIntegerProperty
-  | TuyaDeviceFunctionEnumProperty
-  | TuyaDeviceFunctionJSONProperty;
-
-export type TuyaDeviceFunction = {
-  code: string;
-  name: string;
-  desc: string;
-  type: TuyaDeviceFunctionType;
-  values: string;
-};
+export type TuyaDeviceSchemaProperty = TuyaDeviceSchemaIntegerProperty
+  | TuyaDeviceSchemaEnumProperty
+  | TuyaDeviceSchemaObjectProperty;
 
 export type TuyaDeviceStatus = {
   code: string;
   value: string | number | boolean;
+};
+
+export type TuyaDeviceSchema = {
+  code: string;
+  // name: string;
+  mode: TuyaDeviceSchemaMode;
+  type: TuyaDeviceSchemaType;
+  values: string;
+  property: TuyaDeviceSchemaProperty; // JSON.parse(schema.values);
 };
 
 export default class TuyaDevice {
@@ -52,7 +60,7 @@ export default class TuyaDevice {
   product_name!: string;
   icon!: string;
   category!: string;
-  functions!: TuyaDeviceFunction[];
+  schema!: TuyaDeviceSchema[];
 
   // status
   status!: TuyaDeviceStatus[];
@@ -74,19 +82,11 @@ export default class TuyaDevice {
     Object.assign(this, obj);
   }
 
-  getDeviceFunction(code: string) {
-    return this.functions.find(_function => _function.code === code);
+  getSchema(code: string) {
+    return this.schema.find(schema => schema.code === code);
   }
 
-  getDeviceFunctionProperty(code: string) {
-    const deviceFunction = this.getDeviceFunction(code);
-    if (!deviceFunction) {
-      return;
-    }
-    return JSON.parse(deviceFunction.values) as TuyaDeviceFunctionProperty;
-  }
-
-  getDeviceStatus(code: string) {
+  getStatus(code: string) {
     return this.status.find(status => status.code === code);
   }
 

--- a/src/device/TuyaHomeDeviceManager.ts
+++ b/src/device/TuyaHomeDeviceManager.ts
@@ -1,4 +1,4 @@
-import TuyaDevice, { TuyaDeviceFunction } from './TuyaDevice';
+import TuyaDevice from './TuyaDevice';
 import TuyaDeviceManager from './TuyaDeviceManager';
 
 export default class TuyaHomeDeviceManager extends TuyaDeviceManager {
@@ -24,21 +24,8 @@ export default class TuyaHomeDeviceManager extends TuyaDeviceManager {
       return [];
     }
 
-    const devIds: string[] = [];
     for (const device of devices) {
-      devIds.push(device.id);
-    }
-
-    const functions = await this.getDeviceListFunctions(devIds);
-
-    for (const device of devices) {
-      for (const item of functions) {
-        if (device.product_id === item['product_id']) {
-          device.functions = item['functions'] as TuyaDeviceFunction[];
-          break;
-        }
-      }
-      device.functions = device.functions || [];
+      device.schema = await this.getDeviceSchema(device.id);
     }
 
     this.devices = devices;

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { PLATFORM_NAME } from '../src/settings';
 import { TuyaPlatformConfig } from '../src/config';
-import TuyaDevice from '../src/device/TuyaDevice';
+import TuyaDevice, { TuyaDeviceSchema } from '../src/device/TuyaDevice';
 import { TuyaOpenAPIResponse } from '../src/core/TuyaOpenAPI';
 
 const file = fs.readFileSync(`${process.env.HOME}/.homebridge-dev/config.json`);
@@ -20,9 +20,18 @@ export function expectDevice(device: TuyaDevice) {
 
   expect(device.product_id.length).toBeGreaterThan(0);
   expect(device.category.length).toBeGreaterThan(0);
-  expect(device.functions).toBeDefined();
+  for (const schema of device.schema) {
+    expectDeviceSchema(schema);
+  }
 
   expect(device.status).toBeDefined();
+}
+
+export function expectDeviceSchema(schema: TuyaDeviceSchema) {
+  expect(schema.code.length).toBeGreaterThan(0);
+  expect(schema.mode.length).toBeGreaterThan(0);
+  expect(schema.type.length).toBeGreaterThan(0);
+  expect(schema.property).toBeDefined();
 }
 
 export function expectSuccessResponse(res: TuyaOpenAPIResponse) {


### PR DESCRIPTION
Combine `functions`(Standard Instruction Set) and `status`(Standard Status Set) into `schema` because:
- `function` is the keywork of TypeScript
- `status` conflict with device status
- `schema` is the history name of `function` + `status`, it can be found on "Tuya iOS Home SDK" and "Tuya Android Home SDK" with the same meaning. 