### PR TITLE
adding support for whitelisting homes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Before configuration, please goto [Tuya IoT Platform](https://iot.tuya.com)
 - `options.username` - **required** : Username
 - `options.password` - **required** : Password
 - `options.appSchema` - **required** : App schema. 'tuyaSmart' for Tuya Smart App, 'smartlife' for Smart Life App.
-- `options.homeWhitelist` - **optional**: If present, only includes devices matching this Home ID value.
+- `options.homeWhitelist` - **optional**: An array of integer home ID values to whitelist. If present, only includes devices matching this Home ID value.
 
 **Note:**
 - The app account can't be used in multiple HomeBridge/HomeAssistant instance at the same time! Please consider using different app accounts instead.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Before configuration, please goto [Tuya IoT Platform](https://iot.tuya.com)
 - `options.username` - **required** : Username
 - `options.password` - **required** : Password
 - `options.appSchema` - **required** : App schema. 'tuyaSmart' for Tuya Smart App, 'smartlife' for Smart Life App.
+- `options.homeWhitelist` - **optional**: If present, only includes devices matching this Home ID value.
 
 **Note:**
 - The app account can't be used in multiple HomeBridge/HomeAssistant instance at the same time! Please consider using different app accounts instead.

--- a/config.schema.json
+++ b/config.schema.json
@@ -89,6 +89,9 @@
 						"items": {
 							"title": "Home ID",
 							"type": "integer"
+						},
+						"condition": {
+							"functionBody": "return model.options.projectType === '2';"
 						}
 					}					
 				}

--- a/config.schema.json
+++ b/config.schema.json
@@ -83,11 +83,12 @@
 						}
 					},
 					"homeWhitelist": {
-						"title": "Whitelisted Home ID",
-						"type": "integer",
-						"required": false,
-						"condition": {
-							"functionBody": "return model.options.projectType === '2';"
+						"title": "Whitelisted Home IDs",
+						"description": "An optional list of Home IDs to match. If blank, all homes are matched.",
+						"type": "array",
+						"items": {
+							"title": "Home ID",
+							"type": "integer"
 						}
 					}					
 				}

--- a/config.schema.json
+++ b/config.schema.json
@@ -81,7 +81,15 @@
 						"condition": {
 							"functionBody": "return model.options.projectType === '2';"
 						}
-					}
+					},
+					"homeWhitelist": {
+						"title": "Whitelisted Home ID",
+						"type": "integer",
+						"required": false,
+						"condition": {
+							"functionBody": "return model.options.projectType === '2';"
+						}
+					}					
 				}
 			}
 		}

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export interface TuyaPlatformHomeConfigOptions {
   username: string;
   password: string;
   appSchema: string;
-  homeWhitelist: number;
+  homeWhitelist: Array<number>;
 }
 
 export type TuyaPlatformConfigOptions = TuyaPlatformCustomConfigOptions | TuyaPlatformHomeConfigOptions;
@@ -42,6 +42,6 @@ export const homeOptionsSchema = {
     username: { type: 'string', required: true },
     password: { type: 'string', required: true },
     appSchema: { 'type': 'string', required: true },
-    homeWhitelist: { 'type': 'integer', 'minimum': 1},
+    homeWhitelist: { 'type': 'array'},
   },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface TuyaPlatformHomeConfigOptions {
   username: string;
   password: string;
   appSchema: string;
+  homeWhitelist: number;
 }
 
 export type TuyaPlatformConfigOptions = TuyaPlatformCustomConfigOptions | TuyaPlatformHomeConfigOptions;
@@ -41,5 +42,6 @@ export const homeOptionsSchema = {
     username: { type: 'string', required: true },
     password: { type: 'string', required: true },
     appSchema: { 'type': 'string', required: true },
+    homeWhitelist: { 'type': 'integer', 'minimum': 1},
   },
 };

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -254,7 +254,16 @@ export class TuyaPlatform implements DynamicPlatformPlugin {
     const homeIDList: number[] = [];
     for (const { home_id, name } of res.result) {
       this.log.info(`Got home_id=${home_id}, name=${name}`);
-      homeIDList.push(home_id);
+      if (this.options.homeWhitelist) {
+        if (home_id === this.options.homeWhitelist) {
+            this.log.info(`Matched home_id=${home_id} to whitelist; adding to homeIDList`);
+            homeIDList.push(home_id);
+        } else {
+            this.log.info(`Did not match home_id=${home_id} to whitelist; not adding to homeIDList`);
+        }
+      } else {
+        homeIDList.push(home_id);
+      }
     }
 
     if (homeIDList.length === 0) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -255,11 +255,11 @@ export class TuyaPlatform implements DynamicPlatformPlugin {
     for (const { home_id, name } of res.result) {
       this.log.info(`Got home_id=${home_id}, name=${name}`);
       if (this.options.homeWhitelist) {
-        if (home_id === this.options.homeWhitelist) {
-            this.log.info(`Matched home_id=${home_id} to whitelist; adding to homeIDList`);
+        if (this.options.homeWhitelist.includes(home_id)) {
+            this.log.info(`Found home_id=${home_id} in whitelist; including devices from this home.`);
             homeIDList.push(home_id);
         } else {
-            this.log.info(`Did not match home_id=${home_id} to whitelist; not adding to homeIDList`);
+            this.log.info(`Did not find home_id=${home_id} in whitelist; excluding devices from this home.`);
         }
       } else {
         homeIDList.push(home_id);


### PR DESCRIPTION
Hey @0x5e — I've just created a quick PR which adds support for whitelisting a single home based on the home's ID number.  If the `options.homeWhitelist` key is unconfigured it includes all homes and devices as previously, but if configured it ignores all but the whitelisted home.

I've also added it to the `config.schema.json` so it's configurable through the settings dialog in `homebridge-config-ui-x`. Hopefully this is useful to you! If there are any changes you'd like me to make, please let me know. 🙂 