### PR TITLE
Use spray_mode only on supported devices

### DIFF
--- a/src/accessory/HumidifierAccessory.ts
+++ b/src/accessory/HumidifierAccessory.ts
@@ -124,7 +124,12 @@ export default class HumidifierAccessory extends BaseAccessory {
   }
 
   setSprayModeToHumidity() {
-    this.sendCommands([{ code: 'spray_mode', value: 'humidity' }]);
+    const schema = this.getSchema('spray_mode');
+    if (!schema) {
+      this.log.debug('Spray mode not supported.');
+      return;
+    }
+    this.sendCommands([{ code: schema.code, value: 'humidity' }]);
   }
 
 }


### PR DESCRIPTION
Hi, @0x5e. I noted spray_mode is a DP instruction and we can't use it on all humidifiers. So I did small patch to fix it.