### PR TITLE
Add requiredSchemaCodes() to match non-standard devices.

### DIFF
--- a/src/accessory/AccessoryFactory.ts
+++ b/src/accessory/AccessoryFactory.ts
@@ -35,7 +35,7 @@ export default class AccessoryFactory {
     device: TuyaDevice,
   ): BaseAccessory {
 
-    let handler;
+    let handler : BaseAccessory | undefined;
     switch (device.category) {
       case 'kj':
         // TODO AirPurifierAccessory
@@ -126,8 +126,12 @@ export default class AccessoryFactory {
     }
 
     if (!handler) {
-      platform.log.warn(`Create accessory using legacy mode: ${device.name}.`);
       handler = LegacyAccessoryFactory.createAccessory(platform, accessory, device);
+      handler && platform.log.warn(`Create accessory using legacy mode: ${device.name}.`);
+    }
+
+    if (handler && handler.checkRequirements && !handler.checkRequirements()) {
+      handler = undefined;
     }
 
     if (!handler) {

--- a/src/accessory/BaseAccessory.ts
+++ b/src/accessory/BaseAccessory.ts
@@ -115,8 +115,15 @@ export default class BaseAccessory {
   }
 
 
-  getSchema(code: string) {
-    return this.device.schema.find(schema => schema.code === code);
+  getSchema(...codes: string[]) {
+    for (const code of codes) {
+      const schema = this.device.schema.find(schema => schema.code === code);
+      if (!schema) {
+        continue;
+      }
+      return schema;
+    }
+    return undefined;
   }
 
   getStatus(code: string) {
@@ -152,6 +159,27 @@ export default class BaseAccessory {
     this.debounceSendCommands();
   }
 
+  checkRequirements() {
+    let result = true;
+    for (const codes of this.requiredSchema()) {
+      const schema = this.getSchema(...codes);
+      if (schema) {
+        continue;
+      }
+      this.log.warn('"%s" is missing one of the required schema: %s', this.device.name, codes);
+      result = false;
+    }
+
+    if (!result) {
+      this.log.warn('Existing schema: %o', this.device.schema);
+    }
+
+    return result;
+  }
+
+  requiredSchema(): string[][] {
+    return [];
+  }
 
   configureService(schema: TuyaDeviceSchema) {
 

--- a/src/accessory/CarbonDioxideSensorAccessory.ts
+++ b/src/accessory/CarbonDioxideSensorAccessory.ts
@@ -1,35 +1,58 @@
 import { PlatformAccessory } from 'homebridge';
 import { TuyaPlatform } from '../platform';
+import { limit } from '../util/util';
 import BaseAccessory from './BaseAccessory';
+
+const SCHEMA_CODE = {
+  CO2_STATUS: ['co2_state'],
+  CO2_LEVEL: ['co2_value'],
+};
+
 
 export default class CarbonDioxideSensorAccessory extends BaseAccessory {
 
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
-    const service = this.accessory.getService(this.Service.CarbonDioxideSensor)
+    this.configureCarbonDioxideDetected();
+    this.configureCarbonDioxideLevel();
+  }
+
+  requiredSchema() {
+    return [SCHEMA_CODE.CO2_STATUS];
+  }
+
+  mainService() {
+    return this.accessory.getService(this.Service.CarbonDioxideSensor)
       || this.accessory.addService(this.Service.CarbonDioxideSensor);
+  }
 
-    if (this.getStatus('co2_state')) {
-      service.getCharacteristic(this.Characteristic.CarbonDioxideDetected)
-        .onGet(() => {
-          const status = this.getStatus('co2_state');
-          return (status!.value === 'alarm') ?
-            this.Characteristic.CarbonDioxideDetected.CO2_LEVELS_ABNORMAL :
-            this.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL;
-        });
+  configureCarbonDioxideDetected() {
+    const schema = this.getSchema(...SCHEMA_CODE.CO2_STATUS);
+    if (!schema) {
+      return;
     }
 
-    if (this.getStatus('co2_value')) {
-      service.getCharacteristic(this.Characteristic.CarbonDioxideLevel)
-        .onGet(() => {
-          const status = this.getStatus('co2_value');
-          let value = Math.max(0, status!.value as number);
-          value = Math.min(100000, value);
-          return value;
-        });
+    const { CO2_LEVELS_ABNORMAL, CO2_LEVELS_NORMAL } = this.Characteristic.CarbonDioxideDetected;
+    this.mainService().getCharacteristic(this.Characteristic.CarbonDioxideDetected)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        return (status.value === 'alarm') ? CO2_LEVELS_ABNORMAL : CO2_LEVELS_NORMAL;
+      });
+  }
+
+  configureCarbonDioxideLevel() {
+    const schema = this.getSchema(...SCHEMA_CODE.CO2_LEVEL);
+    if (!schema) {
+      return;
     }
 
+    this.mainService().getCharacteristic(this.Characteristic.CarbonDioxideLevel)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        const value = limit(status.value as number, 0, 100000);
+        return value;
+      });
   }
 
 }

--- a/src/accessory/CarbonMonoxideSensorAccessory.ts
+++ b/src/accessory/CarbonMonoxideSensorAccessory.ts
@@ -1,37 +1,56 @@
 import { PlatformAccessory } from 'homebridge';
 import { TuyaPlatform } from '../platform';
+import { limit } from '../util/util';
 import BaseAccessory from './BaseAccessory';
+
+const SCHEMA_CODE = {
+  CO_STATUS: ['co_status', 'co_state'],
+  CO_LEVEL: ['co_value'],
+};
 
 export default class CarbonMonoxideSensorAccessory extends BaseAccessory {
 
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
-    const service = this.accessory.getService(this.Service.CarbonMonoxideSensor)
-      || this.accessory.addService(this.Service.CarbonMonoxideSensor);
-
-    if (this.getStatus('co_status')
-      || this.getStatus('co_state')) {
-      service.getCharacteristic(this.Characteristic.CarbonMonoxideDetected)
-        .onGet(() => {
-          const status = this.getStatus('co_status')
-            || this.getStatus('co_state');
-          return (status!.value === 'alarm' || status!.value === '1') ?
-            this.Characteristic.CarbonMonoxideDetected.CO_LEVELS_ABNORMAL :
-            this.Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL;
-        });
-    }
-
-    if (this.getStatus('co_value')) {
-      service.getCharacteristic(this.Characteristic.CarbonMonoxideLevel)
-        .onGet(() => {
-          const status = this.getStatus('co_value');
-          let value = Math.max(0, status!.value as number);
-          value = Math.min(100, value);
-          return value;
-        });
-    }
-
+    this.configureCarbonMonoxideDetected();
+    this.configureCarbonMonoxideLevel();
   }
 
+  requiredSchema() {
+    return [SCHEMA_CODE.CO_STATUS];
+  }
+
+  mainService() {
+    return this.accessory.getService(this.Service.CarbonMonoxideSensor)
+      || this.accessory.addService(this.Service.CarbonMonoxideSensor);
+  }
+
+  configureCarbonMonoxideDetected() {
+    const schema = this.getSchema(...SCHEMA_CODE.CO_STATUS);
+    if (!schema) {
+      return;
+    }
+
+    const { CO_LEVELS_ABNORMAL, CO_LEVELS_NORMAL } = this.Characteristic.CarbonMonoxideDetected;
+    this.mainService().getCharacteristic(this.Characteristic.CarbonMonoxideDetected)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        return (status.value === 'alarm' || status.value === '1') ? CO_LEVELS_ABNORMAL : CO_LEVELS_NORMAL;
+      });
+  }
+
+  configureCarbonMonoxideLevel() {
+    const schema = this.getSchema(...SCHEMA_CODE.CO_LEVEL);
+    if (!schema) {
+      return;
+    }
+
+    this.mainService().getCharacteristic(this.Characteristic.CarbonMonoxideLevel)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        const value = limit(status.value as number, 0, 100);
+        return value;
+      });
+  }
 }

--- a/src/accessory/ContactSensorAccessory.ts
+++ b/src/accessory/ContactSensorAccessory.ts
@@ -2,15 +2,19 @@ import { PlatformAccessory } from 'homebridge';
 import { TuyaPlatform } from '../platform';
 import BaseAccessory from './BaseAccessory';
 
+const SCHEMA_CODE = {
+  CONTACT_STATE: ['doorcontact_state', 'switch'],
+};
+
 export default class ContaceSensor extends BaseAccessory {
 
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
-    const schema = this.getContactSensorSchema();
+    const schema = this.getSchema(...SCHEMA_CODE.CONTACT_STATE);
     if (schema) {
       const service = this.accessory.getService(this.Service.ContactSensor)
-      || this.accessory.addService(this.Service.ContactSensor);
+        || this.accessory.addService(this.Service.ContactSensor);
 
       const { CONTACT_NOT_DETECTED, CONTACT_DETECTED } = this.Characteristic.ContactSensorState;
       service.getCharacteristic(this.Characteristic.ContactSensorState)
@@ -19,13 +23,10 @@ export default class ContaceSensor extends BaseAccessory {
           return status.value ? CONTACT_NOT_DETECTED : CONTACT_DETECTED;
         });
     }
-
-
   }
 
-  getContactSensorSchema() {
-    return this.getSchema('doorcontact_state')
-      || this.getSchema('switch');
+  requiredSchema() {
+    return [SCHEMA_CODE.CONTACT_STATE];
   }
 
 }

--- a/src/accessory/HumanPresenceSensorAccessory.ts
+++ b/src/accessory/HumanPresenceSensorAccessory.ts
@@ -2,23 +2,37 @@ import { PlatformAccessory } from 'homebridge';
 import { TuyaPlatform } from '../platform';
 import BaseAccessory from './BaseAccessory';
 
+const SCHEMA_CODE = {
+  PRESENCE: ['presence_state'],
+};
+
 export default class HumanPresenceSensorAccessory extends BaseAccessory {
 
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
-    if (this.getStatus('presence_state')) {
-      const service = this.accessory.getService(this.Service.OccupancySensor)
+    this.configureOccupancyDetected();
+  }
+
+  requiredSchema() {
+    return [SCHEMA_CODE.PRESENCE];
+  }
+
+  configureOccupancyDetected() {
+    const schema = this.getSchema(...SCHEMA_CODE.PRESENCE);
+    if (!schema) {
+      return;
+    }
+
+    const { OCCUPANCY_DETECTED, OCCUPANCY_NOT_DETECTED } = this.Characteristic.OccupancyDetected;
+    const service = this.accessory.getService(this.Service.OccupancySensor)
       || this.accessory.addService(this.Service.OccupancySensor);
 
-      service.getCharacteristic(this.Characteristic.OccupancyDetected)
-        .onGet(() => {
-          const status = this.getStatus('presence_state');
-          return (status?.value === 'presence') ?
-            this.Characteristic.OccupancyDetected.OCCUPANCY_DETECTED :
-            this.Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED;
-        });
-    }
+    service.getCharacteristic(this.Characteristic.OccupancyDetected)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        return (status.value === 'presence') ? OCCUPANCY_DETECTED : OCCUPANCY_NOT_DETECTED;
+      });
   }
 
 }

--- a/src/accessory/LeakSensorAccessory.ts
+++ b/src/accessory/LeakSensorAccessory.ts
@@ -2,11 +2,16 @@ import { PlatformAccessory } from 'homebridge';
 import { TuyaPlatform } from '../platform';
 import BaseAccessory from './BaseAccessory';
 
+const SCHEMA_CODE = {
+  LEAK: ['gas_sensor_status', 'gas_sensor_state', 'ch4_sensor_state', 'watersensor_state'],
+};
+
 export default class LeakSensor extends BaseAccessory {
 
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
+    const { LEAK_NOT_DETECTED, LEAK_DETECTED } = this.Characteristic.LeakDetected;
     const service = this.accessory.getService(this.Service.LeakSensor)
       || this.accessory.addService(this.Service.LeakSensor);
 
@@ -20,12 +25,16 @@ export default class LeakSensor extends BaseAccessory {
         if ((gas && (gas.value === 'alarm' || gas.value === '1'))
           || (ch4 && ch4.value === 'alarm')
           || (water && water.value === 'alarm')) {
-          return this.Characteristic.LeakDetected.LEAK_DETECTED;
+          return LEAK_DETECTED;
         } else {
-          return this.Characteristic.LeakDetected.LEAK_NOT_DETECTED;
+          return LEAK_NOT_DETECTED;
         }
       });
 
+  }
+
+  requiredSchema() {
+    return [SCHEMA_CODE.LEAK];
   }
 
 }

--- a/src/accessory/MotionSensorAccessory.ts
+++ b/src/accessory/MotionSensorAccessory.ts
@@ -2,22 +2,36 @@ import { PlatformAccessory } from 'homebridge';
 import { TuyaPlatform } from '../platform';
 import BaseAccessory from './BaseAccessory';
 
+const SCHEMA_CODE = {
+  PIR: ['pir'],
+};
+
 export default class MotionSensorAccessory extends BaseAccessory {
 
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
-    if (this.getStatus('pir')) {
-      const service = this.accessory.getService(this.Service.MotionSensor)
-        || this.accessory.addService(this.Service.MotionSensor);
+    this.configureMotionDetected();
+  }
 
-      service.getCharacteristic(this.Characteristic.MotionDetected)
-        .onGet(() => {
-          const status = this.getStatus('pir');
-          return (status!.value === 'pir');
-        });
+  requiredSchema() {
+    return [SCHEMA_CODE.PIR];
+  }
+
+  configureMotionDetected() {
+    const schema = this.getSchema(...SCHEMA_CODE.PIR);
+    if (!schema) {
+      return;
     }
 
+    const service = this.accessory.getService(this.Service.MotionSensor)
+      || this.accessory.addService(this.Service.MotionSensor);
+
+    service.getCharacteristic(this.Characteristic.MotionDetected)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        return (status.value === 'pir');
+      });
   }
 
 }

--- a/src/accessory/SmokeSensorAccessory.ts
+++ b/src/accessory/SmokeSensorAccessory.ts
@@ -2,26 +2,41 @@ import { PlatformAccessory } from 'homebridge';
 import { TuyaPlatform } from '../platform';
 import BaseAccessory from './BaseAccessory';
 
+const SCHEMA_CODE = {
+  SENSOR_STATUS: ['smoke_sensor_status', 'smoke_sensor_state'],
+};
+
 export default class SmokeSensor extends BaseAccessory {
 
   constructor(platform: TuyaPlatform, accessory: PlatformAccessory) {
     super(platform, accessory);
 
+    this.configureSmokeDetected();
+  }
+
+  requiredSchema() {
+    return [SCHEMA_CODE.SENSOR_STATUS];
+  }
+
+  configureSmokeDetected() {
+    const schema = this.getSchema(...SCHEMA_CODE.SENSOR_STATUS);
+    if (!schema) {
+      return;
+    }
+
+    const { LEAK_NOT_DETECTED, LEAK_DETECTED } = this.Characteristic.LeakDetected;
     const service = this.accessory.getService(this.Service.SmokeSensor)
       || this.accessory.addService(this.Service.SmokeSensor);
 
     service.getCharacteristic(this.Characteristic.SmokeDetected)
       .onGet(() => {
-        const status = this.getStatus('smoke_sensor_status')
-          || this.getStatus('smoke_sensor_state');
-
-        if ((status && (status.value === 'alarm' || status.value === '1'))) {
-          return this.Characteristic.LeakDetected.LEAK_DETECTED;
+        const status = this.getStatus(schema.code)!;
+        if ((status.value === 'alarm' || status.value === '1')) {
+          return LEAK_DETECTED;
         } else {
-          return this.Characteristic.LeakDetected.LEAK_NOT_DETECTED;
+          return LEAK_NOT_DETECTED;
         }
       });
-
   }
 
 }

--- a/src/accessory/SwitchAccessory.ts
+++ b/src/accessory/SwitchAccessory.ts
@@ -1,7 +1,15 @@
 import { TuyaDeviceSchema, TuyaDeviceSchemaType } from '../device/TuyaDevice';
 import BaseAccessory from './BaseAccessory';
 
+const SCHEMA_CODE = {
+  ON: ['switch', 'switch_1'],
+};
+
 export default class SwitchAccessory extends BaseAccessory {
+
+  requiredSchema() {
+    return [SCHEMA_CODE.ON];
+  }
 
   mainService() {
     return this.Service.Switch;

--- a/src/accessory/ValveAccessory.ts
+++ b/src/accessory/ValveAccessory.ts
@@ -1,7 +1,15 @@
 import { TuyaDeviceSchema, TuyaDeviceSchemaType } from '../device/TuyaDevice';
 import BaseAccessory from './BaseAccessory';
 
+const SCHEMA_CODE = {
+  ON: ['switch', 'switch_1'],
+};
+
 export default class ValveAccessory extends BaseAccessory {
+
+  requiredSchema() {
+    return [SCHEMA_CODE.ON];
+  }
 
   configureService(schema: TuyaDeviceSchema) {
     if (!schema.code.startsWith('switch')


### PR DESCRIPTION
I see many "non-standard devices" which doesn't have the required schema. To help users better know about their devices, I've add some checks before using the Accessory class. For example, a light sensor must have `bright_value`, if a device don't have it, plugin will output warning logs.
