### PR TITLE
Expose energy usage for outlets/switches

### DIFF
--- a/src/accessory/SwitchAccessory.ts
+++ b/src/accessory/SwitchAccessory.ts
@@ -24,10 +24,13 @@ export default class SwitchAccessory extends BaseAccessory {
       this.accessory.removeService(oldService);
     }
 
-    const schema = this.device.schema.filter((schema) => schema.code.startsWith('switch') && schema.type === TuyaDeviceSchemaType.Boolean);
-    for (const _schema of schema) {
-      const name = (schema.length === 1) ? this.device.name : _schema.code;
-      this.configureSwitch(_schema, name);
+    const schemata = this.device.schema.filter(
+      (schema) => SCHEMA_CODE.ON.includes(schema.code) && schema.type === TuyaDeviceSchemaType.Boolean,
+    );
+
+    for (const schema of schemata) {
+      const name = (schemata.length === 1) ? this.device.name : schema.code;
+      this.configureSwitch(schema, name);
     }
   }
 

--- a/src/accessory/SwitchAccessory.ts
+++ b/src/accessory/SwitchAccessory.ts
@@ -28,10 +28,10 @@ export default class SwitchAccessory extends BaseAccessory {
       (schema) => SCHEMA_CODE.ON.includes(schema.code) && schema.type === TuyaDeviceSchemaType.Boolean,
     );
 
-    for (const schema of schemata) {
+    schemata.forEach((schema, schemaKey) => {
       const name = (schemata.length === 1) ? this.device.name : schema.code;
-      this.configureSwitch(schema, name);
-    }
+      this.configureSwitch(schema, name, schemaKey === 0);
+    });
   }
 
 
@@ -39,7 +39,7 @@ export default class SwitchAccessory extends BaseAccessory {
     return this.Service.Switch;
   }
 
-  configureSwitch(schema: TuyaDeviceSchema, name: string) {
+  configureSwitch(schema: TuyaDeviceSchema, name: string, energyUsage: boolean) {
 
     const service = this.accessory.getService(schema.code)
       || this.accessory.addService(this.mainService(), name, schema.code);
@@ -51,14 +51,17 @@ export default class SwitchAccessory extends BaseAccessory {
     }
 
     configureOn(this, service, schema);
-    configureEnergyUsage(
-      this.platform.api,
-      this,
-      service,
-      this.getSchema(...SCHEMA_CODE.CURRENT),
-      this.getSchema(...SCHEMA_CODE.POWER),
-      this.getSchema(...SCHEMA_CODE.VOLTAGE),
-    );
+
+    if (energyUsage) {
+      configureEnergyUsage(
+        this.platform.api,
+        this,
+        service,
+        this.getSchema(...SCHEMA_CODE.CURRENT),
+        this.getSchema(...SCHEMA_CODE.POWER),
+        this.getSchema(...SCHEMA_CODE.VOLTAGE),
+      );
+    }
   }
 
 }

--- a/src/accessory/SwitchAccessory.ts
+++ b/src/accessory/SwitchAccessory.ts
@@ -1,9 +1,13 @@
 import { TuyaDeviceSchema, TuyaDeviceSchemaType } from '../device/TuyaDevice';
 import BaseAccessory from './BaseAccessory';
 import { configureOn } from './characteristic/On';
+import { configureEnergyUsage } from './characteristic/EnergyUsage';
 
 const SCHEMA_CODE = {
   ON: ['switch', 'switch_1'],
+  CURRENT: ['cur_current'],
+  POWER: ['cur_power'],
+  VOLTAGE: ['cur_voltage'],
 };
 
 export default class SwitchAccessory extends BaseAccessory {
@@ -44,6 +48,14 @@ export default class SwitchAccessory extends BaseAccessory {
     }
 
     configureOn(this, service, schema);
+    configureEnergyUsage(
+      this.platform.api,
+      this,
+      service,
+      this.getSchema(...SCHEMA_CODE.CURRENT),
+      this.getSchema(...SCHEMA_CODE.POWER),
+      this.getSchema(...SCHEMA_CODE.VOLTAGE),
+    );
   }
 
 }

--- a/src/accessory/SwitchAccessory.ts
+++ b/src/accessory/SwitchAccessory.ts
@@ -4,7 +4,7 @@ import { configureOn } from './characteristic/On';
 import { configureEnergyUsage } from './characteristic/EnergyUsage';
 
 const SCHEMA_CODE = {
-  ON: ['switch', 'switch_1'],
+  ON: ['switch', 'switch_1'], // switch_2, switch_3, switch_4, ..., switch_usb1, switch_usb2, switch_usb3, ..., switch_backlight
   CURRENT: ['cur_current'],
   POWER: ['cur_power'],
   VOLTAGE: ['cur_voltage'],
@@ -25,12 +25,12 @@ export default class SwitchAccessory extends BaseAccessory {
     }
 
     const schemata = this.device.schema.filter(
-      (schema) => SCHEMA_CODE.ON.includes(schema.code) && schema.type === TuyaDeviceSchemaType.Boolean,
+      (schema) => schema.code.startsWith('switch') && schema.type === TuyaDeviceSchemaType.Boolean,
     );
 
-    schemata.forEach((schema, schemaKey) => {
+    schemata.forEach((schema) => {
       const name = (schemata.length === 1) ? this.device.name : schema.code;
-      this.configureSwitch(schema, name, schemaKey === 0);
+      this.configureSwitch(schema, name);
     });
   }
 
@@ -39,7 +39,7 @@ export default class SwitchAccessory extends BaseAccessory {
     return this.Service.Switch;
   }
 
-  configureSwitch(schema: TuyaDeviceSchema, name: string, energyUsage: boolean) {
+  configureSwitch(schema: TuyaDeviceSchema, name: string) {
 
     const service = this.accessory.getService(schema.code)
       || this.accessory.addService(this.mainService(), name, schema.code);
@@ -52,7 +52,7 @@ export default class SwitchAccessory extends BaseAccessory {
 
     configureOn(this, service, schema);
 
-    if (energyUsage) {
+    if (schema.code === this.getSchema(...SCHEMA_CODE.ON)?.code) {
       configureEnergyUsage(
         this.platform.api,
         this,

--- a/src/accessory/characteristic/EnergyUsage.ts
+++ b/src/accessory/characteristic/EnergyUsage.ts
@@ -69,7 +69,6 @@ function createAmperesCharacteristic(api: API) {
         format: api.hap.Formats.FLOAT,
         perms: [api.hap.Perms.NOTIFY, api.hap.Perms.PAIRED_READ],
         unit: 'A',
-        minStep: 0.01,
       });
     }
   };
@@ -84,7 +83,6 @@ function createWattsCharacteristic(api: API) {
         format: api.hap.Formats.FLOAT,
         perms: [api.hap.Perms.NOTIFY, api.hap.Perms.PAIRED_READ],
         unit: 'W',
-        minStep: 0.01,
       });
     }
   };
@@ -99,7 +97,6 @@ function createVoltsCharacteristic(api: API) {
         format: api.hap.Formats.FLOAT,
         perms: [api.hap.Perms.NOTIFY, api.hap.Perms.PAIRED_READ],
         unit: 'V',
-        minStep: 0.01,
       });
     }
   };

--- a/src/accessory/characteristic/EnergyUsage.ts
+++ b/src/accessory/characteristic/EnergyUsage.ts
@@ -1,0 +1,106 @@
+import BaseAccessory from '../BaseAccessory';
+import { API, Service } from 'homebridge';
+import { TuyaDeviceSchema, TuyaDeviceSchemaIntegerProperty } from '../../device/TuyaDevice';
+import OverridedBaseAccessory from '../BaseAccessory';
+
+export function configureEnergyUsage(
+  api: API,
+  accessory: OverridedBaseAccessory,
+  service: Service,
+  currentSchema?: TuyaDeviceSchema,
+  powerSchema?: TuyaDeviceSchema,
+  voltageSchema?: TuyaDeviceSchema,
+) {
+
+  if (currentSchema) {
+    if (isUnit(currentSchema, 'A', 'mA')) {
+      const amperes = createAmperesCharacteristic(api);
+      if (!service.testCharacteristic(amperes)) {
+        service.addCharacteristic(amperes).onGet(
+          createStatusGetter(accessory, currentSchema.code, isUnit(currentSchema, 'mA') ? 1000 : 0),
+        );
+      }
+    } else {
+      accessory.log.warn('Unsupported current unit %p', currentSchema);
+    }
+  }
+
+  if (powerSchema) {
+    if (isUnit(powerSchema, 'W')) {
+      const watts = createWattsCharacteristic(api);
+      if (!service.testCharacteristic(watts)) {
+        service.addCharacteristic(watts).onGet(createStatusGetter(accessory, powerSchema.code));
+      }
+    } else {
+      accessory.log.warn('Unsupported power unit %p', currentSchema);
+    }
+  }
+
+  if (voltageSchema) {
+    if (isUnit(voltageSchema, 'V')) {
+      const volts = createVoltsCharacteristic(api);
+      if (!service.testCharacteristic(volts)) {
+        service.addCharacteristic(volts).onGet(createStatusGetter(accessory, voltageSchema.code));
+      }
+    } else {
+      accessory.log.warn('Unsupported voltage unit %p', currentSchema);
+    }
+  }
+}
+
+function isUnit(schema: TuyaDeviceSchema, ...units: string[]): boolean {
+  return units.includes((schema.property as TuyaDeviceSchemaIntegerProperty).unit);
+}
+
+function createStatusGetter(accessory: BaseAccessory, code: string, divisor = 1): () => number {
+  return () => {
+    const status = accessory.getStatus(code)!;
+
+    return (status.value as number) / divisor;
+  };
+}
+
+function createAmperesCharacteristic(api: API) {
+  return class Amperes extends api.hap.Characteristic {
+    static readonly UUID = 'E863F126-079E-48FF-8F27-9C2605A29F52';
+
+    constructor() {
+      super('Amperes', Amperes.UUID, {
+        format: api.hap.Formats.FLOAT,
+        perms: [api.hap.Perms.NOTIFY, api.hap.Perms.PAIRED_READ],
+        unit: 'A',
+        minStep: 0.01,
+      });
+    }
+  };
+}
+
+function createWattsCharacteristic(api: API) {
+  return class Watts extends api.hap.Characteristic {
+    static readonly UUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
+
+    constructor() {
+      super('Consumption', Watts.UUID, {
+        format: api.hap.Formats.FLOAT,
+        perms: [api.hap.Perms.NOTIFY, api.hap.Perms.PAIRED_READ],
+        unit: 'W',
+        minStep: 0.01,
+      });
+    }
+  };
+}
+
+function createVoltsCharacteristic(api: API) {
+  return class Volts extends api.hap.Characteristic {
+    static readonly UUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52';
+
+    constructor() {
+      super('Volts', Volts.UUID, {
+        format: api.hap.Formats.FLOAT,
+        perms: [api.hap.Perms.NOTIFY, api.hap.Perms.PAIRED_READ],
+        unit: 'V',
+        minStep: 0.01,
+      });
+    }
+  };
+}


### PR DESCRIPTION
Apps like Eve Home support showing energy usage information. Additionally plugins like https://www.npmjs.com/package/homebridge-prometheus-exporter can export energy usage data into a timeseries DB. This adds support for watts, voltage and amperes.

The supported energy statistics are modeled exactly after https://github.com/plasticrake/homebridge-tplink-smarthome. The custom characteristics are basically verbatim copies.

### Demo
<img width="400px" src="https://user-images.githubusercontent.com/79707/210152150-4fcd35b9-fb88-45d6-b906-9b36cf19ce79.jpeg"/>
