### PR TITLE
add switch command only if needed

### DIFF
--- a/src/accessory/ThermostatAccessory.ts
+++ b/src/accessory/ThermostatAccessory.ts
@@ -127,11 +127,19 @@ export default class ThermostatAccessory extends BaseAccessory {
         const commands: TuyaDeviceStatus[] = [];
 
         // Thermostat valve may not support 'Power Off'
-        if (this.getStatus('switch')) {
-          commands.push({
-            code: 'switch',
-            value: (value === OFF) ? false : true,
-          });
+        const on = this.getStatus('switch');
+        if (on) {
+          if (value === OFF) {
+            commands.push({
+              code: 'switch',
+              value: false,
+            });
+          } else if (on.value === false) {
+            commands.push({
+              code: 'switch',
+              value: true,
+            });
+          }
         }
 
         if (schema) {


### PR DESCRIPTION
I have Avatto smart thermostat. I saw in the log that when the mode is changed `{switch: true}` command is send every time this was preventing the `mode` to be set. I've tested it in the tuya device debug to send only the `mode` command and its work but if you add `{switch: true}` command (when the device is already on) along with the `mode` the `mode` is ignored