### PR TITLE
Order temp before get the min and max for IRAirConditionerAccessory

### DIFF
--- a/src/accessory/IRAirConditionerAccessory.ts
+++ b/src/accessory/IRAirConditionerAccessory.ts
@@ -231,8 +231,10 @@ export default class IRAirConditionerAccessory extends BaseAccessory {
       return undefined;
     }
 
-    const min = keyRangeItem.temp_list[0].temp;
-    const max = keyRangeItem.temp_list[keyRangeItem.temp_list.length - 1].temp;
+    const tempList = data.temp_list.map((temp) => temp.temp);
+
+    const min = Math.min(...tempList);
+    const max = Math.max(...tempList);
     return [min, max];
   }
 

--- a/src/accessory/IRAirConditionerAccessory.ts
+++ b/src/accessory/IRAirConditionerAccessory.ts
@@ -231,7 +231,7 @@ export default class IRAirConditionerAccessory extends BaseAccessory {
       return undefined;
     }
 
-    const tempList = data.temp_list.map((temp) => temp.temp);
+    const tempList = keyRangeItem.temp_list.map((temp) => temp.temp);
 
     const min = Math.min(...tempList);
     const max = Math.max(...tempList);


### PR DESCRIPTION
I was getting this error when adding a new IR Air:
<img width="1427" alt="image" src="https://github.com/0x5e/homebridge-tuya-platform/assets/22357579/b690502e-fb9e-4381-be47-3db65ec1a7f3">

I saw that the minimum value was `32` and max `31` on the logs.
After debugging the code, I saw that the code gets the minimum value from array position `0`, printing the array I got this:
![image](https://github.com/0x5e/homebridge-tuya-platform/assets/22357579/f467ecb9-d0cc-4ea7-bd7e-d5d6f99f94b1)

I another IR Air the values are ordered:
<img width="628" alt="image" src="https://github.com/0x5e/homebridge-tuya-platform/assets/22357579/70976536-b1c3-45ff-a514-74c628185470">

So, I change the code to get the `min` and `max` values using the `Math` object.
