### PR TITLE
Weather station support

### DIFF
--- a/src/accessory/AccessoryFactory.ts
+++ b/src/accessory/AccessoryFactory.ts
@@ -197,6 +197,9 @@ export default class AccessoryFactory {
       case 'wxml':
         handler = new DoorbellAccessory(platform, accessory);
         break;
+      case "qxj":
+        handler = new WeatherStationAccessory(platform, accessory);
+        break;
 
       // Other
       case 'scene':

--- a/src/accessory/AccessoryFactory.ts
+++ b/src/accessory/AccessoryFactory.ts
@@ -40,6 +40,7 @@ import IRGenericAccessory from './IRGenericAccessory';
 import IRAirConditionerAccessory from './IRAirConditionerAccessory';
 import SecuritySystemAccessory from './SecuritySystemAccessory';
 import VibrationSensorAccessory from './VibrationSensorAccessory';
+import WeatherStationAccessory from './WeatherStationAccessory';
 import DoorbellAccessory from './DoorbellAccessory';
 import PetFeederAccessory from './PetFeederAccessory';
 

--- a/src/accessory/AccessoryFactory.ts
+++ b/src/accessory/AccessoryFactory.ts
@@ -197,7 +197,7 @@ export default class AccessoryFactory {
       case 'wxml':
         handler = new DoorbellAccessory(platform, accessory);
         break;
-      case "qxj":
+      case 'qxj':
         handler = new WeatherStationAccessory(platform, accessory);
         break;
 

--- a/src/accessory/WeatherStationAccessory.ts
+++ b/src/accessory/WeatherStationAccessory.ts
@@ -1,79 +1,60 @@
-import BaseAccessory from "./BaseAccessory";
+import BaseAccessory from './BaseAccessory';
 
 export default class TemperatureHumiditySensorAccessory extends BaseAccessory {
-    configureServices(): void {
-        const { temperatureSchemas, humiditySchemas } =
-            this.getDynamicSchemaCodes();
+  configureServices(): void {
+    const { temperatureSchemas, humiditySchemas } = this.getDynamicSchemaCodes();
 
-        temperatureSchemas.forEach((schema, index) => {
-            const serviceName = `Temperature Sensor ${index + 1}`;
-            const serviceSubtype = `temperature_sensor_${index + 1}`;
-            const service =
-                this.accessory.getServiceById(
-                    this.Service.TemperatureSensor,
-                    serviceSubtype
-                ) ||
-                this.accessory.addService(
-                    this.Service.TemperatureSensor,
-                    serviceName,
-                    serviceSubtype
-                );
+    temperatureSchemas.forEach((schema, index) => {
+      const serviceName = `Temperature Sensor ${index + 1}`;
+      const serviceSubtype = `temperature_sensor_${index + 1}`;
+      const service =
+        this.accessory.getServiceById(this.Service.TemperatureSensor, serviceSubtype) ||
+        this.accessory.addService(this.Service.TemperatureSensor, serviceName, serviceSubtype);
 
-            service
-                .getCharacteristic(this.Characteristic.CurrentTemperature)
-                .onGet(() => {
-                    const status = this.getStatus(schema.code);
-                    if (status) {
-                        const property = this.getSchema(schema.code)
-                            ?.property as any;
-                        const multiple = Math.pow(10, property.scale || 0);
-                        return Math.min(
-                            Math.max((status.value as number) / multiple, -100),
-                            100
-                        );
-                    }
-                    return 0; // Default value if no status is found
-                });
+      service
+        .getCharacteristic(this.Characteristic.CurrentTemperature)
+        .onGet(() => {
+          const status = this.getStatus(schema.code);
+          if (status) {
+            const property = this.getSchema(schema.code)?.property as { scale: number };
+            const multiple = Math.pow(10, property.scale || 0);
+            return Math.min(Math.max((status.value as number) / multiple, -100), 100);
+          }
+          return 0; // Default value if no status is found
         });
+    });
 
-        humiditySchemas.forEach((schema, index) => {
-            const serviceName = `Humidity Sensor ${index + 1}`;
-            const serviceSubtype = `humidity_sensor_${index + 1}`;
-            const service =
-                this.accessory.getServiceById(
-                    this.Service.HumiditySensor,
-                    serviceSubtype
-                ) ||
-                this.accessory.addService(
-                    this.Service.HumiditySensor,
-                    serviceName,
-                    serviceSubtype
-                );
+    humiditySchemas.forEach((schema, index) => {
+      const serviceName = `Humidity Sensor ${index + 1}`;
+      const serviceSubtype = `humidity_sensor_${index + 1}`;
+      const service =
+        this.accessory.getServiceById(this.Service.HumiditySensor, serviceSubtype) ||
+        this.accessory.addService(this.Service.HumiditySensor, serviceName, serviceSubtype);
 
-            service
-                .getCharacteristic(this.Characteristic.CurrentRelativeHumidity)
-                .onGet(() => {
-                    const status = this.getStatus(schema.code);
-                    if (status) {
-                        return status.value as number;
-                    }
-                    return 0; // Default value if no status is found
-                });
+      service
+        .getCharacteristic(this.Characteristic.CurrentRelativeHumidity)
+        .onGet(() => {
+          const status = this.getStatus(schema.code);
+          if (status) {
+            return status.value as number;
+          }
+          return 0; // Default value if no status is found
         });
-    }
+    });
+  }
 
-    private getDynamicSchemaCodes() {
-        const temperatureSchemas: any[] = [];
-        const humiditySchemas: any[] = [];
+  private getDynamicSchemaCodes() {
+    const temperatureSchemas: { code: string }[] = [];
+    const humiditySchemas: { code: string }[] = [];
 
-        this.device.schema.forEach((schema) => {
-            if (schema.code.includes("ToutCh")) {
-                temperatureSchemas.push(schema);
-            } else if (schema.code.includes("HoutCh")) {
-                humiditySchemas.push(schema);
-            }
-        });
+    this.device.schema.forEach((schema) => {
+      if (schema.code.includes('ToutCh')) {
+        temperatureSchemas.push(schema);
+      } else if (schema.code.includes('HoutCh')) {
+        humiditySchemas.push(schema);
+      }
+    });
 
-        return { temperatureSchemas, humiditySchemas };
-    }
+    return { temperatureSchemas, humiditySchemas };
+  }
 }

--- a/src/accessory/WeatherStationAccessory.ts
+++ b/src/accessory/WeatherStationAccessory.ts
@@ -1,0 +1,79 @@
+import BaseAccessory from "./BaseAccessory";
+
+export default class TemperatureHumiditySensorAccessory extends BaseAccessory {
+    configureServices(): void {
+        const { temperatureSchemas, humiditySchemas } =
+            this.getDynamicSchemaCodes();
+
+        temperatureSchemas.forEach((schema, index) => {
+            const serviceName = `Temperature Sensor ${index + 1}`;
+            const serviceSubtype = `temperature_sensor_${index + 1}`;
+            const service =
+                this.accessory.getServiceById(
+                    this.Service.TemperatureSensor,
+                    serviceSubtype
+                ) ||
+                this.accessory.addService(
+                    this.Service.TemperatureSensor,
+                    serviceName,
+                    serviceSubtype
+                );
+
+            service
+                .getCharacteristic(this.Characteristic.CurrentTemperature)
+                .onGet(() => {
+                    const status = this.getStatus(schema.code);
+                    if (status) {
+                        const property = this.getSchema(schema.code)
+                            ?.property as any;
+                        const multiple = Math.pow(10, property.scale || 0);
+                        return Math.min(
+                            Math.max((status.value as number) / multiple, -100),
+                            100
+                        );
+                    }
+                    return 0; // Default value if no status is found
+                });
+        });
+
+        humiditySchemas.forEach((schema, index) => {
+            const serviceName = `Humidity Sensor ${index + 1}`;
+            const serviceSubtype = `humidity_sensor_${index + 1}`;
+            const service =
+                this.accessory.getServiceById(
+                    this.Service.HumiditySensor,
+                    serviceSubtype
+                ) ||
+                this.accessory.addService(
+                    this.Service.HumiditySensor,
+                    serviceName,
+                    serviceSubtype
+                );
+
+            service
+                .getCharacteristic(this.Characteristic.CurrentRelativeHumidity)
+                .onGet(() => {
+                    const status = this.getStatus(schema.code);
+                    if (status) {
+                        return status.value as number;
+                    }
+                    return 0; // Default value if no status is found
+                });
+        });
+    }
+
+    private getDynamicSchemaCodes() {
+        const temperatureSchemas: any[] = [];
+        const humiditySchemas: any[] = [];
+
+        this.device.schema.forEach((schema) => {
+            if (schema.code.includes("ToutCh")) {
+                temperatureSchemas.push(schema);
+            } else if (schema.code.includes("HoutCh")) {
+                humiditySchemas.push(schema);
+            }
+        });
+
+        return { temperatureSchemas, humiditySchemas };
+    }
+}


### PR DESCRIPTION
Hello, I saw a few people wanting to add multiple temp sensors for weather stations, but this wasn't possible. So I added the support for a weather station `qxj` - An example config might be like:

```
"schema": [
                            {
                                "code": "ToutCh1",
                                "newCode": "va_temperature"
                            },
                            {
                                "code": "HoutCh1",
                                "newCode": "humidity_value"
                            },
                            {
                                "code": "ToutCh2",
                                "newCode": "va_temperature"
                            },
                            {
                                "code": "HoutCh2",
                                "newCode": "humidity_value"
                            },
                            {
                                "code": "ToutCh3",
                                "newCode": "va_temperature"
                            },
                            {
                                "code": "HoutCh3",
                                "newCode": "humidity_value"
                            }
                        ]
```

<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/0x5e/homebridge-tuya-platform/pull/495)
<!-- GitContextEnd -->