### PR TITLE
Light not detected properly when only color temperature is available

### DIFF
--- a/src/accessory/characteristic/Light.ts
+++ b/src/accessory/characteristic/Light.ts
@@ -47,6 +47,8 @@ function getLightType(
     lightType = LightType.C;
   } else if (on && !bright && !temp) {
     lightType = LightType.Normal;
+  } else if (on && !bright && temp) {
+    lightType = LightType.Normal;
   } else {
     lightType = LightType.Unknown;
   }


### PR DESCRIPTION
### Bug: Light not detected properly when only color temperature is available

**Summary:**
Some Tuya light devices expose only a `temp_value` DP (color temperature) without a `bright_value`
(brightness), for example certain fan-integrated lights (`fs` / `fsd` category).

In this case, the plugin logs `Light type: Unknown`, and the light toggle in HomeKit has no effect.

**Expected behavior:**
These devices should be treated as `LightType.Normal` (basic on/off + temperature), not `Unknown`.

**Solution:**
The light type detection logic in `getLightType(...)` should include a case for:
```js
if (on && !bright && temp) {
  lightType = LightType.Normal;
}
