### PR TITLE
feat: add Cat Toilet (msp) accessory support

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -84,7 +84,7 @@ Most category code is pinyin abbreviation of Chinese name.
 | Sofa                       | 沙发 | sf            | | | [Documentation](https://developer.tuya.com/en/docs/iot/categorysf?id=Kaiuz2fp9uqtt)      |
 | Electric Fireplace         | 电壁炉 | dbl           | | | [Documentation](https://developer.tuya.com/en/docs/iot/electric-fireplace?id=Kaiuz2hz4iyp6) |
 | Smart Milk Kettle          | 智能调奶器 | tnq           | | | [Documentation](https://developer.tuya.com/en/docs/iot/categorytnq?id=Kakf01agbfkfa)     |
-| Cat Toilet                 | 猫砂盆 | msp           | | | [Documentation](https://developer.tuya.com/en/docs/iot/categorymsp?id=Kakg2t7714ky7)     |
+| Cat Toilet                 | 猫砂盆 | msp           | Switch, Lightbulb, OccupancySensor, FilterMaintenance | ✅ | [Documentation](https://developer.tuya.com/en/docs/iot/categorymsp?id=Kakg2t7714ky7)     |
 | Towel Rack                 | 毛巾架 | mjj           | | | [Documentation](https://developer.tuya.com/en/docs/iot/categorymjj?id=Kakkmlm9k4cir)     |
 | Smart Indoor Garden        | 植物生长机 | sz            | | | [Documentation](https://developer.tuya.com/en/docs/iot/categorysz?id=Kaiuz4e6h7up0)      |
 

--- a/src/accessory/AccessoryFactory.ts
+++ b/src/accessory/AccessoryFactory.ts
@@ -43,6 +43,7 @@ import VibrationSensorAccessory from './VibrationSensorAccessory';
 import WeatherStationAccessory from './WeatherStationAccessory';
 import DoorbellAccessory from './DoorbellAccessory';
 import PetFeederAccessory from './PetFeederAccessory';
+import CatToiletAccessory from './CatToiletAccessory';
 import WhiteNoiseLightAccessory from './WhiteNoiseLightAccessory';
 
 
@@ -121,6 +122,9 @@ export default class AccessoryFactory {
         break;
       case 'cwwsq':
         handler = new PetFeederAccessory(platform, accessory);
+        break;
+      case 'msp':
+        handler = new CatToiletAccessory(platform, accessory);
         break;
       case 'mc':
         handler = new WindowAccessory(platform, accessory);

--- a/src/accessory/CatToiletAccessory.ts
+++ b/src/accessory/CatToiletAccessory.ts
@@ -1,0 +1,149 @@
+import BaseAccessory from './BaseAccessory';
+import { configureName } from './characteristic/Name';
+import { configureOn } from './characteristic/On';
+
+const SCHEMA_CODE = {
+  SWITCH: ['switch'],
+  AUTO_CLEAN: ['auto_clean'],
+  MANUAL_CLEAN: ['manual_clean'],
+  DEODORIZATION: ['deodorization'],
+  UV: ['uv'],
+  LIGHT: ['light'],
+  STATUS: ['status'],
+  CAT_WEIGHT: ['cat_weight'],
+  EXCRETION_TIMES: ['excretion_times_day'],
+  EXCRETION_TIME: ['excretion_time_day'],
+  NOTIFICATION: ['notification'],
+  FAULT: ['fault'],
+};
+
+export default class CatToiletAccessory extends BaseAccessory {
+
+  requiredSchema() {
+    return [SCHEMA_CODE.SWITCH];
+  }
+
+  configureServices() {
+    // Main power switch
+    configureOn(this, this.mainService(), this.getSchema(...SCHEMA_CODE.SWITCH));
+    configureName(this, this.mainService(), this.device.name);
+
+    // Additional switches
+    this.configureSwitch(SCHEMA_CODE.AUTO_CLEAN, 'Auto Clean');
+    this.configureSwitch(SCHEMA_CODE.MANUAL_CLEAN, 'Manual Clean');
+    this.configureSwitch(SCHEMA_CODE.DEODORIZATION, 'Deodorization');
+    this.configureSwitch(SCHEMA_CODE.UV, 'UV Sterilization');
+
+    // Mood light as Lightbulb
+    this.configureLight();
+
+    // Occupancy sensor for active status
+    this.configureOccupancySensor();
+
+    // Filter maintenance for garbage box full
+    this.configureFilterMaintenance();
+
+    // Fault handling
+    this.configureFault();
+  }
+
+  mainService() {
+    return this.accessory.getService(this.Service.Switch)
+      || this.accessory.addService(this.Service.Switch, this.device.name, 'switch');
+  }
+
+  configureSwitch(schemaCodes: string[], name: string) {
+    const schema = this.getSchema(...schemaCodes);
+    if (!schema) {
+      return;
+    }
+
+    const service = this.accessory.getService(schema.code)
+      || this.accessory.addService(this.Service.Switch, name, schema.code);
+
+    configureName(this, service, name);
+    configureOn(this, service, schema);
+  }
+
+  configureLight() {
+    const schema = this.getSchema(...SCHEMA_CODE.LIGHT);
+    if (!schema) {
+      return;
+    }
+
+    const service = this.accessory.getService(schema.code)
+      || this.accessory.addService(this.Service.Lightbulb, 'Mood Light', schema.code);
+
+    configureName(this, service, 'Mood Light');
+    service.getCharacteristic(this.Characteristic.On)
+      .onGet(() => {
+        this.checkOnlineStatus();
+        const status = this.getStatus(schema.code)!;
+        return status.value as boolean;
+      })
+      .onSet(async value => {
+        await this.sendCommands([{
+          code: schema.code,
+          value: value as boolean,
+        }], true);
+      });
+  }
+
+  configureOccupancySensor() {
+    const schema = this.getSchema(...SCHEMA_CODE.STATUS);
+    if (!schema) {
+      return;
+    }
+
+    const service = this.accessory.getService(this.Service.OccupancySensor)
+      || this.accessory.addService(this.Service.OccupancySensor, 'Status', 'status');
+
+    configureName(this, service, 'Status');
+
+    const { OCCUPANCY_DETECTED, OCCUPANCY_NOT_DETECTED } = this.Characteristic.OccupancyDetected;
+    service.getCharacteristic(this.Characteristic.OccupancyDetected)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        const activeStates = ['cleaning', 'uv', 'deodorization'];
+        return activeStates.includes(status.value as string)
+          ? OCCUPANCY_DETECTED
+          : OCCUPANCY_NOT_DETECTED;
+      });
+  }
+
+  configureFilterMaintenance() {
+    const schema = this.getSchema(...SCHEMA_CODE.NOTIFICATION);
+    if (!schema) {
+      return;
+    }
+
+    const service = this.accessory.getService(this.Service.FilterMaintenance)
+      || this.accessory.addService(this.Service.FilterMaintenance, 'Waste Box', 'notification');
+
+    configureName(this, service, 'Waste Box');
+
+    const { CHANGE_FILTER, FILTER_OK } = this.Characteristic.FilterChangeIndication;
+    service.getCharacteristic(this.Characteristic.FilterChangeIndication)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        // Bit 0 = garbage_box_full
+        const value = status.value as number;
+        return (value & 1) ? CHANGE_FILTER : FILTER_OK;
+      });
+  }
+
+  configureFault() {
+    const schema = this.getSchema(...SCHEMA_CODE.FAULT);
+    if (!schema) {
+      return;
+    }
+
+    // Add fault status to main service
+    this.mainService().getCharacteristic(this.Characteristic.StatusFault)
+      .onGet(() => {
+        const status = this.getStatus(schema.code)!;
+        const { GENERAL_FAULT, NO_FAULT } = this.Characteristic.StatusFault;
+        return (status.value as number) > 0 ? GENERAL_FAULT : NO_FAULT;
+      });
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `CatToiletAccessory` for Tuya **msp** (Cat Toilet) category devices.

### Services Exposed

| Service | DP Code | Description |
|---------|---------|-------------|
| Switch (Power) | `switch` | Main power on/off |
| Switch (Auto Clean) | `auto_clean` | Toggle automatic cleaning |
| Switch (Manual Clean) | `manual_clean` | Trigger a clean cycle |
| Switch (Deodorization) | `deodorization` | Toggle deodorization |
| Switch (UV) | `uv` | Toggle UV sterilization |
| Lightbulb | `light` | Mood light control |
| OccupancySensor | `status` | Shows occupied during active cleaning/UV/deodorization |
| FilterMaintenance | `notification` | Change filter alert when garbage box is full (bit 0) |
| StatusFault | `fault` | Motor/program/sensor fault indication on main switch |

All services are **optional** — if the device doesn't report a DP in its schema, that service is silently skipped. Follows existing code patterns (BaseAccessory helpers, `configureOn`/`configureName` characteristic helpers, service subtypes).

### Changes
- `src/accessory/CatToiletAccessory.ts` — New accessory handler
- `src/accessory/AccessoryFactory.ts` — Added `case 'msp'` mapping
- `SUPPORTED_DEVICES.md` — Updated msp row

### Testing
- Builds successfully with zero TypeScript errors
- Tested against known msp device DP schemas