### PR TITLE
Fix single-light fan regression introduced in #550

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,20 +7,20 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        # the Node.js versions to build on
-        node-version: [12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }} 
-        uses: actions/setup-node@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint the project
         run: npm run lint

--- a/src/accessory/FanAccessory.ts
+++ b/src/accessory/FanAccessory.ts
@@ -54,7 +54,7 @@ export default class FanAccessory extends BaseAccessory {
 
     this.configureRotationDirection();
 
-    // Light
+    // Dual-light: two independent light channels (warm + white)
     const warmOn = this.getSchema('light');
     const warmBright = this.getSchema('bright_value');
     const coldOn = this.getSchema('switch_led');
@@ -68,19 +68,19 @@ export default class FanAccessory extends BaseAccessory {
       const whiteService = this.accessory.getService('White Light')
         || this.accessory.addService(this.Service.Lightbulb, 'White Light', 'white_light');
       configureLight(this, whiteService, coldOn, coldBright);
-    } else if (warmOn) {
+    } else if (this.getSchema(...SCHEMA_CODE.LIGHT_ON)) {
       if (this.lightServiceType() === this.Service.Lightbulb) {
         configureLight(
           this,
           this.lightService(),
-          warmOn,
-          warmBright,
+          this.getSchema(...SCHEMA_CODE.LIGHT_ON),
+          this.getSchema(...SCHEMA_CODE.LIGHT_BRIGHT),
           this.getSchema(...SCHEMA_CODE.LIGHT_TEMP),
           this.getSchema(...SCHEMA_CODE.LIGHT_COLOR),
           this.getSchema(...SCHEMA_CODE.LIGHT_MODE),
         );
       } else if (this.lightServiceType() === this.Service.Switch) {
-        configureOn(this, undefined, warmOn);
+        configureOn(this, undefined, this.getSchema(...SCHEMA_CODE.LIGHT_ON));
         const unusedService = this.accessory.getService(this.Service.Lightbulb);
         unusedService && this.accessory.removeService(unusedService);
       }

--- a/test/FanAccessory.test.ts
+++ b/test/FanAccessory.test.ts
@@ -5,9 +5,14 @@ import FanAccessory from '../src/accessory/FanAccessory';
 import TuyaDevice, { TuyaDeviceSchemaMode, TuyaDeviceSchemaType } from '../src/device/TuyaDevice';
 import { TuyaPlatform } from '../src/platform';
 
-// Mock modules
-jest.mock('../src/accessory/characteristic/Light');
-jest.mock('../src/accessory/characteristic/On');
+const mockConfigureLight = jest.fn();
+const mockConfigureOn = jest.fn();
+jest.mock('../src/accessory/characteristic/Light', () => ({
+  configureLight: (...args: any[]) => mockConfigureLight(...args),
+}));
+jest.mock('../src/accessory/characteristic/On', () => ({
+  configureOn: (...args: any[]) => mockConfigureOn(...args),
+}));
 jest.mock('../src/accessory/characteristic/Active');
 jest.mock('../src/accessory/characteristic/RotationSpeed');
 jest.mock('../src/accessory/characteristic/SwingMode');
@@ -20,7 +25,9 @@ describe('FanAccessory', () => {
   let mockDeviceManager: any;
 
   beforeEach(() => {
-    // Mock API
+    mockConfigureLight.mockClear();
+    mockConfigureOn.mockClear();
+
     mockAPI = {
       hap: {
         Service: {
@@ -46,13 +53,11 @@ describe('FanAccessory', () => {
       },
     } as unknown as API;
 
-    // Mock device manager
     mockDeviceManager = {
       getDevice: jest.fn(),
       sendCommands: jest.fn(),
     };
 
-    // Mock platform
     mockPlatform = {
       api: mockAPI,
       Service: mockAPI.hap.Service,
@@ -72,7 +77,6 @@ describe('FanAccessory', () => {
       getDeviceSchemaConfig: jest.fn(() => undefined),
     } as unknown as TuyaPlatform;
 
-    // Mock accessory
     mockAccessory = {
       UUID: 'mock-uuid',
       displayName: 'Test Fan',
@@ -132,146 +136,322 @@ describe('FanAccessory', () => {
     });
   }
 
-  test('should detect dual-light when all 4 DPs are present', () => {
-    const device = createMockDevice([
-      'switch',
-      'fan_speed',
-      'light',
-      'bright_value',
-      'switch_led',
-      'bright_value_1',
-    ]);
-
+  function setupAndConfigure(codes: string[]) {
+    const device = createMockDevice(codes);
     mockDeviceManager.getDevice.mockReturnValue(device);
-
     const fanAccessory = new FanAccessory(mockPlatform, mockAccessory);
     fanAccessory.configureServices();
+    return fanAccessory;
+  }
 
-    // Should create two separate Lightbulb services
-    const services = mockAccessory.addService.mock.calls;
-    const lightServices = services.filter((call: any[]) =>
+  function getDualLightServices() {
+    return mockAccessory.addService.mock.calls.filter((call: any[]) =>
       call[1] === 'Warm Light' || call[1] === 'White Light',
     );
+  }
 
-    expect(lightServices.length).toBe(2);
-    expect(lightServices[0][1]).toBe('Warm Light');
-    expect(lightServices[0][2]).toBe('warm_light');
-    expect(lightServices[1][1]).toBe('White Light');
-    expect(lightServices[1][2]).toBe('white_light');
+  function expectNoDualLight() {
+    expect(getDualLightServices().length).toBe(0);
+  }
+
+  function expectLightCall(index: number, onCode: string, brightCode?: string) {
+    const args = mockConfigureLight.mock.calls[index];
+    expect(args[2]).toEqual(expect.objectContaining({ code: onCode }));
+    if (brightCode) {
+      expect(args[3]).toEqual(expect.objectContaining({ code: brightCode }));
+    } else {
+      expect(args[3]).toBeUndefined();
+    }
+  }
+
+  // ─── Fan service type ─────────────────────────────────────────────
+
+  describe('fan service type', () => {
+    test('should use Fanv2 when child_lock present', () => {
+      const fanAccessory = setupAndConfigure(['switch', 'fan_speed', 'child_lock']);
+      expect(fanAccessory.fanServiceType()).toBe(mockAPI.hap.Service.Fanv2);
+    });
+
+    test('should use Fanv2 when swing present', () => {
+      const fanAccessory = setupAndConfigure(['switch', 'fan_speed', 'switch_horizontal']);
+      expect(fanAccessory.fanServiceType()).toBe(mockAPI.hap.Service.Fanv2);
+    });
+
+    test('should use Fan when no lock or swing present', () => {
+      const fanAccessory = setupAndConfigure(['switch', 'fan_speed']);
+      expect(fanAccessory.fanServiceType()).toBe(mockAPI.hap.Service.Fan);
+    });
   });
 
-  test('should fallback to single light when only one set of DPs present', () => {
-    const device = createMockDevice([
-      'switch',
-      'fan_speed',
-      'light',
-      'bright_value',
-    ]);
+  // ─── A. Dual-light path ───────────────────────────────────────────
+  // Requires ALL 4: light + bright_value + switch_led + bright_value_1
 
-    mockDeviceManager.getDevice.mockReturnValue(device);
+  describe('dual-light (all 4 DPs present)', () => {
+    test('light + bright_value + switch_led + bright_value_1', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'light', 'bright_value', 'switch_led', 'bright_value_1',
+      ]);
 
-    const fanAccessory = new FanAccessory(mockPlatform, mockAccessory);
-    fanAccessory.configureServices();
+      const lightServices = getDualLightServices();
+      expect(lightServices.length).toBe(2);
+      expect(lightServices[0][1]).toBe('Warm Light');
+      expect(lightServices[0][2]).toBe('warm_light');
+      expect(lightServices[1][1]).toBe('White Light');
+      expect(lightServices[1][2]).toBe('white_light');
 
-    // Should NOT create separate Warm/White services
-    const services = mockAccessory.addService.mock.calls;
-    const dualLightServices = services.filter((call: any[]) =>
-      call[1] === 'Warm Light' || call[1] === 'White Light',
-    );
+      expect(mockConfigureLight).toHaveBeenCalledTimes(2);
+      expectLightCall(0, 'light', 'bright_value');
+      expectLightCall(1, 'switch_led', 'bright_value_1');
+    });
 
-    expect(dualLightServices.length).toBe(0);
+    test('dual-light with extra bright_value_v2 (ignored)', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'light', 'bright_value', 'bright_value_v2', 'switch_led', 'bright_value_1',
+      ]);
+
+      expect(getDualLightServices().length).toBe(2);
+      expect(mockConfigureLight).toHaveBeenCalledTimes(2);
+      expectLightCall(0, 'light', 'bright_value');
+      expectLightCall(1, 'switch_led', 'bright_value_1');
+    });
+
+    test('dual-light with extra temp_value (not passed to dual-light configureLight)', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'light', 'bright_value', 'switch_led', 'bright_value_1', 'temp_value',
+      ]);
+
+      expect(getDualLightServices().length).toBe(2);
+      expect(mockConfigureLight).toHaveBeenCalledTimes(2);
+      // Dual-light calls only pass on+bright, not temp/color/mode
+      expect(mockConfigureLight.mock.calls[0].length).toBe(4);
+      expect(mockConfigureLight.mock.calls[1].length).toBe(4);
+    });
   });
 
-  test('should not detect dual-light when only switch_led without bright_value_1', () => {
-    const device = createMockDevice([
-      'switch',
-      'fan_speed',
-      'light',
-      'bright_value',
-      'switch_led', // Missing bright_value_1
-    ]);
+  // ─── B. Single-light Lightbulb path ───────────────────────────────
+  // Has LIGHT_ON match + at least one of: bright_value/v2, temp_value/v2, colour_data, work_mode
 
-    mockDeviceManager.getDevice.mockReturnValue(device);
+  describe('single-light as Lightbulb', () => {
+    test('light + bright_value', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'light', 'bright_value']);
 
-    const fanAccessory = new FanAccessory(mockPlatform, mockAccessory);
-    fanAccessory.configureServices();
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'light', 'bright_value');
+    });
 
-    // Should NOT create separate Warm/White services
-    const services = mockAccessory.addService.mock.calls;
-    const dualLightServices = services.filter((call: any[]) =>
-      call[1] === 'Warm Light' || call[1] === 'White Light',
-    );
+    test('light + bright_value_v2', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'light', 'bright_value_v2']);
 
-    expect(dualLightServices.length).toBe(0);
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'light', 'bright_value_v2');
+    });
+
+    test('switch_led + bright_value', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'switch_led', 'bright_value']);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'switch_led', 'bright_value');
+    });
+
+    test('switch_led + bright_value_v2', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'switch_led', 'bright_value_v2']);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'switch_led', 'bright_value_v2');
+    });
+
+    test('light + bright_value + both bright versions (prefers bright_value)', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'light', 'bright_value', 'bright_value_v2']);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'light', 'bright_value');
+    });
+
+    test('light + temp_value only (no brightness)', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'light', 'temp_value']);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      const args = mockConfigureLight.mock.calls[0];
+      expect(args[2]).toEqual(expect.objectContaining({ code: 'light' }));
+      expect(args[3]).toBeUndefined(); // no brightness DP
+      expect(args[4]).toEqual(expect.objectContaining({ code: 'temp_value' }));
+    });
+
+    test('switch_led + temp_value_v2 only', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'switch_led', 'temp_value_v2']);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      const args = mockConfigureLight.mock.calls[0];
+      expect(args[2]).toEqual(expect.objectContaining({ code: 'switch_led' }));
+      expect(args[4]).toEqual(expect.objectContaining({ code: 'temp_value_v2' }));
+    });
+
+    test('light + bright_value + temp_value + colour_data + work_mode (full feature set)', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'light', 'bright_value', 'temp_value', 'colour_data', 'work_mode',
+      ]);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      const args = mockConfigureLight.mock.calls[0];
+      expect(args[2]).toEqual(expect.objectContaining({ code: 'light' }));
+      expect(args[3]).toEqual(expect.objectContaining({ code: 'bright_value' }));
+      expect(args[4]).toEqual(expect.objectContaining({ code: 'temp_value' }));
+      expect(args[5]).toEqual(expect.objectContaining({ code: 'colour_data' }));
+      expect(args[6]).toEqual(expect.objectContaining({ code: 'work_mode' }));
+    });
+
+    test('both on/off DPs + switch_led fallback: prefers light (LIGHT_ON order)', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'light', 'switch_led', 'bright_value']);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'light', 'bright_value');
+    });
   });
 
-  test('should not detect dual-light when only bright_value_1 without switch_led', () => {
-    const device = createMockDevice([
-      'switch',
-      'fan_speed',
-      'light',
-      'bright_value',
-      'bright_value_1', // Missing switch_led
-    ]);
+  // ─── C. Single-light Switch path ──────────────────────────────────
+  // Has LIGHT_ON match but NO brightness/temp/color/mode DPs
 
-    mockDeviceManager.getDevice.mockReturnValue(device);
+  describe('single-light as Switch (on/off only)', () => {
+    test('light only', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'light']);
 
-    const fanAccessory = new FanAccessory(mockPlatform, mockAccessory);
-    fanAccessory.configureServices();
+      expectNoDualLight();
+      expect(mockConfigureLight).not.toHaveBeenCalled();
+      expect(mockConfigureOn).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ code: 'light' }),
+      );
+    });
 
-    // Should NOT create separate Warm/White services
-    const services = mockAccessory.addService.mock.calls;
-    const dualLightServices = services.filter((call: any[]) =>
-      call[1] === 'Warm Light' || call[1] === 'White Light',
-    );
+    test('switch_led only', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'switch_led']);
 
-    expect(dualLightServices.length).toBe(0);
+      expectNoDualLight();
+      expect(mockConfigureLight).not.toHaveBeenCalled();
+      expect(mockConfigureOn).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ code: 'switch_led' }),
+      );
+    });
+
+    test('light + switch_led, no brightness (prefers light)', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'light', 'switch_led']);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).not.toHaveBeenCalled();
+      expect(mockConfigureOn).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ code: 'light' }),
+      );
+    });
   });
 
-  test('should handle fan with no light at all', () => {
-    const device = createMockDevice([
-      'switch',
-      'fan_speed',
-    ]);
+  // ─── D. No light ──────────────────────────────────────────────────
 
-    mockDeviceManager.getDevice.mockReturnValue(device);
+  describe('no light at all', () => {
+    test('fan-only device', () => {
+      setupAndConfigure(['switch', 'fan_speed']);
 
-    const fanAccessory = new FanAccessory(mockPlatform, mockAccessory);
-    fanAccessory.configureServices();
+      expectNoDualLight();
+      expect(mockConfigureLight).not.toHaveBeenCalled();
+    });
 
-    // Should NOT create any light services
-    const services = mockAccessory.addService.mock.calls;
-    const lightServices = services.filter((call: any[]) =>
-      call[0].name === 'Lightbulb' || call[1]?.includes('Light'),
-    );
+    test('brightness DPs without any on/off DP are ignored', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'bright_value']);
 
-    expect(lightServices.length).toBe(0);
+      expectNoDualLight();
+      expect(mockConfigureLight).not.toHaveBeenCalled();
+    });
+
+    test('bright_value_1 alone is ignored', () => {
+      setupAndConfigure(['switch', 'fan_speed', 'bright_value_1']);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).not.toHaveBeenCalled();
+    });
   });
 
-  test('should use Fanv2 when lock or swing present', () => {
-    const device = createMockDevice([
-      'switch',
-      'fan_speed',
-      'child_lock',
-    ]);
+  // ─── E. Edge cases: dual-light guard must NOT match ────────────────
+  // These are the critical backward-compatibility scenarios.
+  // Each has 3 of the 4 required DPs but not the 4th,
+  // so must fall through to the single-light path.
 
-    mockDeviceManager.getDevice.mockReturnValue(device);
+  describe('partial dual-light DPs (must NOT trigger dual-light)', () => {
+    test('missing bright_value_1: light + bright_value + switch_led', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'light', 'bright_value', 'switch_led',
+      ]);
 
-    const fanAccessory = new FanAccessory(mockPlatform, mockAccessory);
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'light', 'bright_value');
+    });
 
-    expect(fanAccessory.fanServiceType()).toBe(mockAPI.hap.Service.Fanv2);
-  });
+    test('missing switch_led: light + bright_value + bright_value_1', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'light', 'bright_value', 'bright_value_1',
+      ]);
 
-  test('should use Fan when no lock or swing present', () => {
-    const device = createMockDevice([
-      'switch',
-      'fan_speed',
-    ]);
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'light', 'bright_value');
+    });
 
-    mockDeviceManager.getDevice.mockReturnValue(device);
+    test('missing bright_value: light + switch_led + bright_value_1', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'light', 'switch_led', 'bright_value_1',
+      ]);
 
-    const fanAccessory = new FanAccessory(mockPlatform, mockAccessory);
+      expectNoDualLight();
+      // lightServiceType: no bright_value/v2, no temp, no color, no mode → Switch
+      expect(mockConfigureLight).not.toHaveBeenCalled();
+      expect(mockConfigureOn).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ code: 'light' }),
+      );
+    });
 
-    expect(fanAccessory.fanServiceType()).toBe(mockAPI.hap.Service.Fan);
+    test('missing light: switch_led + bright_value + bright_value_1', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'switch_led', 'bright_value', 'bright_value_1',
+      ]);
+
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'switch_led', 'bright_value');
+    });
+
+    test('has bright_value_v2 instead of bright_value: light + bright_value_v2 + switch_led + bright_value_1', () => {
+      setupAndConfigure([
+        'switch', 'fan_speed',
+        'light', 'bright_value_v2', 'switch_led', 'bright_value_1',
+      ]);
+
+      // bright_value is MISSING so dual-light guard fails
+      expectNoDualLight();
+      expect(mockConfigureLight).toHaveBeenCalledTimes(1);
+      expectLightCall(0, 'light', 'bright_value_v2');
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fixes a regression introduced in #550 that broke light control for single-light fans using `switch_led` or `bright_value_v2` DPs. Also updates the CI workflow to use Node.js versions compatible with the current dependency chain.

## Changes
- Restored `getSchema(...SCHEMA_CODE.LIGHT_ON)` and `getSchema(...SCHEMA_CODE.LIGHT_BRIGHT)` in the single-light fallback path so all DP variants (`light`/`switch_led`, `bright_value`/`bright_value_v2`) are handled correctly
- Expanded unit tests from 7 to 26 cases covering every meaningful DP combination
- Maintains dual-light support for fans with all 4 DPs (`light`, `bright_value`, `switch_led`, `bright_value_1`)
- Updated CI Node.js matrix from `[12-19]` to `[18, 20, 22]` to match actual dependency requirements (see details below)

## Device Compatibility
Verified with all known single-light fan DP combinations:
- `light` + `bright_value`
- `light` + `bright_value_v2`
- `switch_led` + `bright_value`
- `switch_led` + `bright_value_v2`
- `light` or `switch_led` only (on/off switch, no brightness)
- Full feature set: `light` + `bright_value` + `temp_value` + `colour_data` + `work_mode`

## CI Update
The locked dependency chain requires Node >= 18 (`tar@7.5.7`, `minizlib@3.1.0`, `chownr@3.0.0` all declare `node >=18`), and `ffmpeg-for-homebridge@2.2.1` uses `require("node:os")` which needs Node 16+. The old CI matrix (12.x–19.x) included EOL/odd versions that can no longer install dependencies, while missing the LTS versions users actually run (20.x, 22.x).

Changes:
- Node matrix: `[18.x, 20.x, 22.x]` — aligned with Homebridge 1.7+ support (`^18 || ^20 || ^22`)
- `npm ci` instead of `npm install` — deterministic installs from the lockfile
- `fail-fast: false` — all jobs run independently
- `actions/checkout@v4`, `actions/setup-node@v4` — replace deprecated v3

## Testing
- ✅ All 26 unit tests pass (+ 2 existing = 28 total)
- ✅ TypeScript build succeeds
- ✅ Linter passes with no warnings
- ✅ Tests verified against pre-PR original code: all 23 single-light tests pass identically, proving 100% backward compatibility
- ✅ Tests verified against buggy #550 code: confirms the 7 regressions this fix resolves